### PR TITLE
fix(ci): run app unit tests as Nx targets

### DIFF
--- a/apps/android-sync/package.json
+++ b/apps/android-sync/package.json
@@ -12,6 +12,7 @@
         "build:android:debug": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build build:debug",
         "build:android:sign": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build sign",
         "preview": "vite preview",
+        "test": "vitest run --config ../../vitest.config.ts --root .",
         "typecheck": "tsc --noEmit",
         "e2e": "sh -c 'pnpm build:android:debug && vitest run --config vitest.e2e.config.ts'",
         "e2e-ci": "sh -c 'pnpm build:android:debug && vitest run --config vitest.e2e.config.ts'",

--- a/apps/chat/package.json
+++ b/apps/chat/package.json
@@ -12,6 +12,7 @@
         "build:android:debug": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build build:debug",
         "build:android:sign": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build sign",
         "preview": "vite preview",
+        "test": "vitest run --config ../../vitest.config.ts --root .",
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {

--- a/apps/five-in-a-row/package.json
+++ b/apps/five-in-a-row/package.json
@@ -12,6 +12,7 @@
         "build:android:debug": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build build:debug",
         "build:android:sign": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build sign",
         "preview": "vite preview",
+        "test": "vitest run --config ../../vitest.config.ts --root .",
         "typecheck": "tsc --noEmit"
     },
     "dependencies": {

--- a/apps/price-converter/package.json
+++ b/apps/price-converter/package.json
@@ -12,6 +12,7 @@
         "build:android:debug": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build build:debug",
         "build:android:sign": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build sign",
         "preview": "vite preview",
+        "test": "vitest run --config ../../vitest.config.ts --root .",
         "typecheck": "tsc --noEmit",
         "e2e": "sh -c 'pnpm build:android:debug && vitest run --config vitest.e2e.config.ts'",
         "e2e-ci": "sh -c 'pnpm build:android:debug && vitest run --config vitest.e2e.config.ts'",

--- a/apps/price-converter/src/app/AddCurrencyScreen/AddCurrencyButton.test.tsx
+++ b/apps/price-converter/src/app/AddCurrencyScreen/AddCurrencyButton.test.tsx
@@ -1,31 +1,36 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test, vi } from 'vitest';
-import { AddCurrencyButtonPure } from './AddCurrencyButton.js';
+import type { NavigatorScreen } from '../../state/State.js';
+import { ADD_CURRENCY_BUTTON_TEST_ID, AddCurrencyButtonPure } from './AddCurrencyButton.js';
 
-const createTestComponent = () => {
-    const navigate = vi.fn();
+interface CreateTestComponentProps {
+    readonly navigate?: (screen: NavigatorScreen) => void;
+}
+
+const createTestComponent = ({ navigate = vi.fn() }: CreateTestComponentProps = {}) => {
     const deps = { navigate };
     const AddCurrencyButton = () => <>{AddCurrencyButtonPure(deps)}</>;
 
-    return { navigate, AddCurrencyButton };
+    return AddCurrencyButton;
 };
 
 describe('AddCurrencyButtonPure', () => {
     test('renders a button with Add Currency tooltip', () => {
-        const { AddCurrencyButton } = createTestComponent();
+        const AddCurrencyButton = createTestComponent();
 
         render(<AddCurrencyButton />);
 
-        expect(screen.getByRole('button')).toBeInTheDocument();
+        expect(screen.getByTestId(ADD_CURRENCY_BUTTON_TEST_ID)).toBeInTheDocument();
     });
 
     test('calls navigate with AddCurrency on click', async () => {
         const user = userEvent.setup();
-        const { navigate, AddCurrencyButton } = createTestComponent();
+        const navigate = vi.fn();
+        const AddCurrencyButton = createTestComponent({ navigate });
 
         render(<AddCurrencyButton />);
-        await user.click(screen.getByRole('button'));
+        await user.click(screen.getByTestId(ADD_CURRENCY_BUTTON_TEST_ID));
 
         expect(navigate).toHaveBeenCalledWith('AddCurrency');
     });

--- a/apps/price-converter/src/app/AddCurrencyScreen/AddCurrencyButton.tsx
+++ b/apps/price-converter/src/app/AddCurrencyScreen/AddCurrencyButton.tsx
@@ -7,8 +7,17 @@ type AddCurrencyButtonDeps = NavigateDep<NavigatorScreen>;
 
 export type AddCurrencyButtonDep = { AddCurrencyButton: FC };
 
+export const ADD_CURRENCY_BUTTON_TEST_ID = 'ADD_CURRENCY_BUTTON';
+
 export const AddCurrencyButtonPure = (deps: AddCurrencyButtonDeps) => {
     const onClick = () => deps.navigate('AddCurrency');
 
-    return <FloatButton icon={<PlusOutlined />} onClick={onClick} tooltip="Add Currency" />;
+    return (
+        <FloatButton
+            icon={<PlusOutlined />}
+            onClick={onClick}
+            tooltip="Add Currency"
+            testId={ADD_CURRENCY_BUTTON_TEST_ID}
+        />
+    );
 };

--- a/apps/scale-cake/package.json
+++ b/apps/scale-cake/package.json
@@ -12,6 +12,7 @@
         "build:android:debug": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build build:debug",
         "build:android:sign": "APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build sign",
         "preview": "vite preview",
+        "test": "vitest run --config ../../vitest.config.ts --root .",
         "typecheck": "tsc --noEmit",
         "e2e": "sh -c 'pnpm build:android:debug && vitest run --config vitest.e2e.config.ts'",
         "e2e-ci": "sh -c 'pnpm build:android:debug && vitest run --config vitest.e2e.config.ts'",

--- a/packages/components/src/FloatButton.tsx
+++ b/packages/components/src/FloatButton.tsx
@@ -5,13 +5,15 @@ interface FloatButtonProps {
     readonly onClick: () => void;
     readonly icon: ReactNode;
     readonly tooltip?: string;
+    readonly testId?: string;
 }
 
-export const FloatButton = ({ onClick, icon, tooltip }: FloatButtonProps) => (
+export const FloatButton = ({ onClick, icon, tooltip, testId }: FloatButtonProps) => (
     <AntFloatButton
         icon={icon}
         type="primary"
         onClick={onClick}
+        data-testid={testId}
         style={{
             width: 56,
             height: 56,

--- a/packages/requirements/src/requirements/appScripts/requiredAppScripts.test.ts
+++ b/packages/requirements/src/requirements/appScripts/requiredAppScripts.test.ts
@@ -67,6 +67,7 @@ describe(requiredAppScripts.name, () => {
                 'build:android:sign':
                     'APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build sign',
                 preview: 'vite preview',
+                test: 'vitest run --config ../../vitest.config.ts --root .',
                 typecheck: 'tsc --noEmit',
             });
         });
@@ -236,6 +237,33 @@ describe(requiredAppScripts.name, () => {
     });
 
     describe('verify', () => {
+        test('app verify requires test script', () => {
+            writePackageJson({
+                dir: appDir,
+                content: {
+                    name: '@minimalist-apps/demo-app',
+                    scripts: {
+                        dev: 'vite',
+                        'dev:android':
+                            'APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build dev',
+                        build: 'vite build',
+                        'build:android':
+                            'APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build build',
+                        'build:android:debug':
+                            'APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build build:debug',
+                        'build:android:sign':
+                            'APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build sign',
+                        preview: 'vite preview',
+                        typecheck: 'tsc --noEmit',
+                    },
+                },
+            });
+
+            const errors = requiredAppScripts.verify({ appDir });
+
+            expect(errors).toEqual(['missing script "test"']);
+        });
+
         test('package verify requires test script', () => {
             writePackageJson({
                 dir: packageDir,

--- a/packages/requirements/src/requirements/appScripts/requiredAppScripts.ts
+++ b/packages/requirements/src/requirements/appScripts/requiredAppScripts.ts
@@ -14,6 +14,7 @@ const expectedScripts: ReadonlyArray<readonly [name: string, value: string]> = [
     ],
     ['build:android:sign', 'APP_DIR=$PWD pnpm --filter @minimalist-apps/android-build sign'],
     ['preview', 'vite preview'],
+    ['test', 'vitest run --config ../../vitest.config.ts --root .'],
     ['typecheck', 'tsc --noEmit'],
 ];
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,2 +1,11 @@
 /// <reference types="@testing-library/jest-dom" />
 import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
+const testCreateResizeObserver = vi.fn(() => ({
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+}));
+
+vi.stubGlobal('ResizeObserver', testCreateResizeObserver);


### PR DESCRIPTION
## Summary

- add centrally enforced unit-test targets to all five apps
- run app tests with the shared JSDOM/Vitest setup while keeping each app as its test root
- provide the ResizeObserver test stub required by Ant Design
- migrate the touched Price Converter test to a stable data-testid

Addresses finding 1 in #86.

## Verification

- pnpm requirements:verify
- all five app test scripts: 90 tests passed
- pnpm format
- pnpm lint:eslint:fix
- pnpm lint:biome
- pnpm lint:eslint
- pnpm typecheck
- pnpm test: 350 tests passed
- pnpm knip