### PR TITLE
feat(evolu): support configurable relays

### DIFF
--- a/apps/android-sync/src/app/SettingsScreen/SettingsScreen.tsx
+++ b/apps/android-sync/src/app/SettingsScreen/SettingsScreen.tsx
@@ -1,5 +1,9 @@
 import type { DebugSettingsDep } from '@minimalist-apps/fragment-debug';
-import type { BackupMnemonicDep, RestoreMnemonicDep } from '@minimalist-apps/fragment-evolu';
+import type {
+    BackupMnemonicDep,
+    EvoluRelaySettingsDep,
+    RestoreMnemonicDep,
+} from '@minimalist-apps/fragment-evolu';
 import { SettingsScreen } from '@minimalist-apps/fragment-settings';
 import type { ThemeModeSettingsDep } from '@minimalist-apps/fragment-theme';
 import type { GoBackDep } from '@minimalist-apps/navigator';
@@ -8,6 +12,7 @@ type SettingsScreenDeps = ThemeModeSettingsDep &
     DebugSettingsDep &
     BackupMnemonicDep &
     RestoreMnemonicDep &
+    EvoluRelaySettingsDep &
     GoBackDep;
 
 export const SettingsScreenPure = (deps: SettingsScreenDeps) => (
@@ -15,6 +20,7 @@ export const SettingsScreenPure = (deps: SettingsScreenDeps) => (
         <deps.ThemeModeSettings />
         <deps.BackupMnemonic />
         <deps.RestoreMnemonic />
+        <deps.EvoluRelaySettings />
         <deps.DebugSettings />
     </SettingsScreen>
 );

--- a/apps/android-sync/src/appStore/createAppStore.ts
+++ b/apps/android-sync/src/appStore/createAppStore.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_EVOLU_RELAY_URLS } from '@minimalist-apps/evolu';
 import type { Store } from '@minimalist-apps/mini-store';
 import { createStore as createMiniStore } from '@minimalist-apps/mini-store';
 import type { AppState } from './AppState';
@@ -12,6 +13,7 @@ export const createAppStore = (): Store<AppState> => {
         debugMode: false,
         evoluMnemonic: null,
         activeOwnerAppId: null,
+        evoluRelayUrls: DEFAULT_EVOLU_RELAY_URLS,
     };
 
     return createMiniStore(initialState);

--- a/apps/android-sync/src/compositionRoot.ts
+++ b/apps/android-sync/src/compositionRoot.ts
@@ -58,7 +58,7 @@ export const createCompositionRoot = (): Main => {
 
     const { ThemeModeSettings } = createThemeFragmentCompositionRoot({ connect, store });
 
-    const { BackupMnemonic, RestoreMnemonic, ensureEvoluStorage } =
+    const { BackupMnemonic, RestoreMnemonic, EvoluRelaySettings, ensureEvoluStorage } =
         createEvoluFragmentCompositionRoot({
             connect,
             store,
@@ -89,6 +89,7 @@ export const createCompositionRoot = (): Main => {
             ThemeModeSettings,
             BackupMnemonic,
             RestoreMnemonic,
+            EvoluRelaySettings,
             DebugSettings,
             goBack,
         });

--- a/apps/android-sync/src/localStorage/storageMaps.test.ts
+++ b/apps/android-sync/src/localStorage/storageMaps.test.ts
@@ -15,6 +15,7 @@ const initState: AppState = {
         'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about' as Mnemonic,
     currentScreen: 'Home',
     activeOwnerAppId: null,
+    evoluRelayUrls: ['wss://one.example', 'wss://two.example'],
 };
 
 describe('storageMaps', () => {
@@ -40,6 +41,7 @@ describe('storageMaps', () => {
         expect(data).toEqual({
             'test-prefix:themeMode': 'dark',
             'test-prefix:debugMode': 'true',
+            'test-prefix:evoluRelayUrls': 'wss://one.example\nwss://two.example',
         });
 
         data['test-prefix:evoluMnemonic'] =
@@ -54,6 +56,7 @@ describe('storageMaps', () => {
         expect(state).toEqual({
             themeMode: 'dark',
             debugMode: true,
+            evoluRelayUrls: ['wss://one.example', 'wss://two.example'],
         });
     });
 });

--- a/apps/android-sync/src/localStorage/storageMaps.ts
+++ b/apps/android-sync/src/localStorage/storageMaps.ts
@@ -1,4 +1,5 @@
 import { isTheme, type Theme } from '@minimalist-apps/components';
+import { parseEvoluRelayUrls } from '@minimalist-apps/evolu';
 import type {
     MapLocalStorageToState,
     MapStateLocalStorage,
@@ -10,6 +11,7 @@ export const localStoragePrefix = 'android-sync-v1';
 export const mapStateLocalStorage: MapStateLocalStorage<AppState> = {
     themeMode: state => state.themeMode,
     debugMode: state => String(state.debugMode),
+    evoluRelayUrls: state => state.evoluRelayUrls.join('\n'),
 };
 
 export const mapLocalStorageToState: MapLocalStorageToState<AppState> = {
@@ -21,4 +23,9 @@ export const mapLocalStorageToState: MapLocalStorageToState<AppState> = {
         return value as Theme;
     },
     debugMode: value => value === 'true',
+    evoluRelayUrls: value => {
+        const result = parseEvoluRelayUrls(value);
+
+        return result.ok ? result.value : undefined;
+    },
 };

--- a/apps/chat/src/app/SettingsScreen/SettingsScreen.tsx
+++ b/apps/chat/src/app/SettingsScreen/SettingsScreen.tsx
@@ -1,5 +1,9 @@
 import type { DebugSettingsDep } from '@minimalist-apps/fragment-debug';
-import type { BackupMnemonicDep, RestoreMnemonicDep } from '@minimalist-apps/fragment-evolu';
+import type {
+    BackupMnemonicDep,
+    EvoluRelaySettingsDep,
+    RestoreMnemonicDep,
+} from '@minimalist-apps/fragment-evolu';
 import { SettingsScreen } from '@minimalist-apps/fragment-settings';
 import type { ThemeModeSettingsDep } from '@minimalist-apps/fragment-theme';
 import type { GoBackDep } from '@minimalist-apps/navigator';
@@ -8,6 +12,7 @@ type SettingsScreenDeps = ThemeModeSettingsDep &
     DebugSettingsDep &
     BackupMnemonicDep &
     RestoreMnemonicDep &
+    EvoluRelaySettingsDep &
     GoBackDep;
 
 export const SettingsScreenPure = (deps: SettingsScreenDeps) => (
@@ -15,6 +20,7 @@ export const SettingsScreenPure = (deps: SettingsScreenDeps) => (
         <deps.ThemeModeSettings />
         <deps.BackupMnemonic />
         <deps.RestoreMnemonic />
+        <deps.EvoluRelaySettings />
         <deps.DebugSettings />
     </SettingsScreen>
 );

--- a/apps/chat/src/appStore/createAppStore.ts
+++ b/apps/chat/src/appStore/createAppStore.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_EVOLU_RELAY_URLS } from '@minimalist-apps/evolu';
 import type { Store } from '@minimalist-apps/mini-store';
 import { createStore as createMiniStore } from '@minimalist-apps/mini-store';
 import type { AppState } from './AppState';
@@ -12,6 +13,7 @@ export const createAppStore = (): Store<AppState> => {
         debugMode: false,
         evoluMnemonic: null,
         activeOwnerAppId: null,
+        evoluRelayUrls: DEFAULT_EVOLU_RELAY_URLS,
     };
 
     return createMiniStore(initialState);

--- a/apps/chat/src/compositionRoot.ts
+++ b/apps/chat/src/compositionRoot.ts
@@ -58,7 +58,7 @@ export const createCompositionRoot = (): Main => {
     const connectAppStore = createConnect({ store });
 
     const { ThemeModeSettings } = createThemeFragmentCompositionRoot({ connect, store });
-    const { BackupMnemonic, RestoreMnemonic, ensureEvoluStorage } =
+    const { BackupMnemonic, RestoreMnemonic, EvoluRelaySettings, ensureEvoluStorage } =
         createEvoluFragmentCompositionRoot({
             connect: connectAppStore,
             store,
@@ -90,6 +90,7 @@ export const createCompositionRoot = (): Main => {
             ThemeModeSettings,
             BackupMnemonic,
             RestoreMnemonic,
+            EvoluRelaySettings,
             DebugSettings,
             goBack,
         });

--- a/apps/chat/src/localStorage/storageMaps.test.ts
+++ b/apps/chat/src/localStorage/storageMaps.test.ts
@@ -18,6 +18,7 @@ const initState: AppState = {
     ),
     currentScreen: 'Chat',
     activeOwnerAppId: null,
+    evoluRelayUrls: ['wss://one.example', 'wss://two.example'],
 };
 
 describe('storageMaps', () => {
@@ -43,6 +44,7 @@ describe('storageMaps', () => {
         expect(data).toEqual({
             'test-prefix:themeMode': 'dark',
             'test-prefix:debugMode': 'true',
+            'test-prefix:evoluRelayUrls': 'wss://one.example\nwss://two.example',
         });
 
         data['test-prefix:evoluMnemonic'] =
@@ -57,6 +59,7 @@ describe('storageMaps', () => {
         expect(state).toEqual({
             themeMode: 'dark',
             debugMode: true,
+            evoluRelayUrls: ['wss://one.example', 'wss://two.example'],
         });
     });
 });

--- a/apps/chat/src/localStorage/storageMaps.ts
+++ b/apps/chat/src/localStorage/storageMaps.ts
@@ -1,4 +1,5 @@
 import { isTheme, type Theme } from '@minimalist-apps/components';
+import { parseEvoluRelayUrls } from '@minimalist-apps/evolu';
 import type {
     MapLocalStorageToState,
     MapStateLocalStorage,
@@ -10,6 +11,7 @@ export const localStoragePrefix = 'chat-v1';
 export const mapStateLocalStorage: MapStateLocalStorage<AppState> = {
     themeMode: state => state.themeMode,
     debugMode: state => String(state.debugMode),
+    evoluRelayUrls: state => state.evoluRelayUrls.join('\n'),
 };
 
 export const mapLocalStorageToState: MapLocalStorageToState<AppState> = {
@@ -21,4 +23,9 @@ export const mapLocalStorageToState: MapLocalStorageToState<AppState> = {
         return value as Theme;
     },
     debugMode: value => value === 'true',
+    evoluRelayUrls: value => {
+        const result = parseEvoluRelayUrls(value);
+
+        return result.ok ? result.value : undefined;
+    },
 };

--- a/apps/price-converter/src/app/SettingsScreen/SettingsScreen.tsx
+++ b/apps/price-converter/src/app/SettingsScreen/SettingsScreen.tsx
@@ -1,5 +1,9 @@
 import type { DebugSettingsDep } from '@minimalist-apps/fragment-debug';
-import type { BackupMnemonicDep, RestoreMnemonicDep } from '@minimalist-apps/fragment-evolu';
+import type {
+    BackupMnemonicDep,
+    EvoluRelaySettingsDep,
+    RestoreMnemonicDep,
+} from '@minimalist-apps/fragment-evolu';
 import { SettingsScreen } from '@minimalist-apps/fragment-settings';
 import type { ThemeModeSettingsDep } from '@minimalist-apps/fragment-theme';
 import type { GoBackDep } from '@minimalist-apps/navigator';
@@ -9,6 +13,7 @@ type SettingsScreenDeps = ThemeModeSettingsDep &
     DebugSettingsDep &
     BackupMnemonicDep &
     RestoreMnemonicDep &
+    EvoluRelaySettingsDep &
     GoBackDep;
 
 export type SettingsScreenDep = { SettingsScreen: FC };
@@ -18,6 +23,7 @@ export const SettingsScreenPure = (deps: SettingsScreenDeps) => (
         <deps.ThemeModeSettings />
         <deps.BackupMnemonic />
         <deps.RestoreMnemonic />
+        <deps.EvoluRelaySettings />
         <deps.DebugSettings />
     </SettingsScreen>
 );

--- a/apps/price-converter/src/compositionRoot.ts
+++ b/apps/price-converter/src/compositionRoot.ts
@@ -91,7 +91,7 @@ export const createCompositionRoot = (): Main => {
 
     // Modules
     const connectAppStore = createConnect({ store: appStore });
-    const { BackupMnemonic, RestoreMnemonic, ensureEvoluStorage } =
+    const { BackupMnemonic, RestoreMnemonic, EvoluRelaySettings, ensureEvoluStorage } =
         createEvoluFragmentCompositionRoot({
             connect: connectAppStore,
             store: appStore,
@@ -230,6 +230,7 @@ export const createCompositionRoot = (): Main => {
             DebugSettings,
             BackupMnemonic,
             RestoreMnemonic,
+            EvoluRelaySettings,
             goBack,
         });
 

--- a/apps/price-converter/src/state/createAppStore.ts
+++ b/apps/price-converter/src/state/createAppStore.ts
@@ -1,4 +1,5 @@
 import type { AmountSats } from '@minimalist-apps/bitcoin';
+import { DEFAULT_EVOLU_RELAY_URLS } from '@minimalist-apps/evolu';
 import type { Store } from '@minimalist-apps/mini-store';
 import { createStore as createMiniStore } from '@minimalist-apps/mini-store';
 import type { State } from './State';
@@ -20,6 +21,7 @@ export const createAppStore = (): Store<State> => {
         debugMode: false,
         evoluMnemonic: null,
         activeOwnerAppId: null,
+        evoluRelayUrls: DEFAULT_EVOLU_RELAY_URLS,
     };
 
     return createMiniStore(initialState);

--- a/apps/price-converter/src/state/localStorage/storageMaps.test.ts
+++ b/apps/price-converter/src/state/localStorage/storageMaps.test.ts
@@ -36,6 +36,7 @@ const initState: State = {
     activeOwnerAppId: null,
     themeMode: 'dark',
     currentScreen: 'Converter',
+    evoluRelayUrls: ['wss://one.example', 'wss://two.example'],
 };
 
 describe('storageMaps', () => {
@@ -63,6 +64,7 @@ describe('storageMaps', () => {
             'test-prefix:lastUpdated': '123',
             'test-prefix:btcMode': 'sats',
             'test-prefix:debugMode': 'true',
+            'test-prefix:evoluRelayUrls': 'wss://one.example\nwss://two.example',
         });
 
         data['test-prefix:evoluMnemonic'] =
@@ -79,6 +81,7 @@ describe('storageMaps', () => {
             lastUpdated: 123,
             btcMode: 'sats',
             debugMode: true,
+            evoluRelayUrls: ['wss://one.example', 'wss://two.example'],
         });
     });
 });

--- a/apps/price-converter/src/state/localStorage/storageMaps.ts
+++ b/apps/price-converter/src/state/localStorage/storageMaps.ts
@@ -1,3 +1,4 @@
+import { parseEvoluRelayUrls } from '@minimalist-apps/evolu';
 import type {
     MapLocalStorageToState,
     MapStateLocalStorage,
@@ -11,6 +12,7 @@ export const mapStateLocalStorage: MapStateLocalStorage<State> = {
     lastUpdated: state => (state.lastUpdated === null ? null : String(state.lastUpdated)),
     btcMode: state => state.btcMode,
     debugMode: state => String(state.debugMode),
+    evoluRelayUrls: state => state.evoluRelayUrls.join('\n'),
 };
 
 export const mapLocalStorageToState: MapLocalStorageToState<State> = {
@@ -22,4 +24,9 @@ export const mapLocalStorageToState: MapLocalStorageToState<State> = {
     },
     btcMode: value => (value === 'sats' ? 'sats' : 'btc'),
     debugMode: value => value === 'true',
+    evoluRelayUrls: value => {
+        const result = parseEvoluRelayUrls(value);
+
+        return result.ok ? result.value : undefined;
+    },
 };

--- a/packages/evolu/src/createEnsureEvoluStorage.test.ts
+++ b/packages/evolu/src/createEnsureEvoluStorage.test.ts
@@ -1,0 +1,33 @@
+import { Mnemonic } from '@evolu/common';
+import { describe, expect, test, vi } from 'vitest';
+import { createEnsureEvoluStorage } from './createEnsureEvoluStorage';
+import { mockEvoluStorage, TodoTestSchema } from './mockEvoluStorage';
+
+const mnemonic = Mnemonic.orThrow(
+    'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+);
+
+describe(createEnsureEvoluStorage.name, () => {
+    test('reads the latest configured relays when storage is first created', async () => {
+        const storage = mockEvoluStorage([]);
+        const createEvoluStorage = vi.fn(() => Promise.resolve(storage));
+        let relayUrls: ReadonlyArray<string> = ['wss://one.example'];
+        const ensureEvoluStorage = createEnsureEvoluStorage({
+            deps: {
+                createEvoluStorage,
+                ensureEvoluOwner: () => Promise.resolve(mnemonic),
+                getEvoluRelayUrls: () => relayUrls,
+                onOwnerUsed: vi.fn(),
+            },
+            schema: TodoTestSchema,
+            appName: 'minimalist-apps-test',
+        });
+
+        relayUrls = ['wss://two.example', 'wss://three.example'];
+        await ensureEvoluStorage();
+
+        expect(createEvoluStorage).toHaveBeenCalledWith(
+            expect.objectContaining({ urls: relayUrls }),
+        );
+    });
+});

--- a/packages/evolu/src/createEnsureEvoluStorage.ts
+++ b/packages/evolu/src/createEnsureEvoluStorage.ts
@@ -14,8 +14,15 @@ export interface OnOwnerUsedDep {
     readonly onOwnerUsed: (owner: Owner) => void;
 }
 
+export interface GetEvoluRelayUrlsDep {
+    readonly getEvoluRelayUrls: () => ReadonlyArray<string>;
+}
+
 interface CreateEnsureEvoluProps<S extends EvoluSchema> {
-    readonly deps: EnsureEvoluOwnerDep & OnOwnerUsedDep & CreateEvoluStorageDep<S>;
+    readonly deps: EnsureEvoluOwnerDep &
+        OnOwnerUsedDep &
+        GetEvoluRelayUrlsDep &
+        CreateEvoluStorageDep<S>;
     readonly schema: ValidateSchema<S> extends never ? S : ValidateSchema<S>;
     readonly appName: string;
     // readonly shardPath: NonEmptyReadonlyArray<string | number>;
@@ -40,7 +47,7 @@ export const createEnsureEvoluStorage = <S extends EvoluSchema>({
                 schema,
                 appName,
                 onOwnerUsed: deps.onOwnerUsed,
-                urls: ['https://free.evoluhq.com'],
+                urls: deps.getEvoluRelayUrls(),
                 // shardPath,
             });
         }

--- a/packages/evolu/src/createEvoluCompositionRoot.ts
+++ b/packages/evolu/src/createEvoluCompositionRoot.ts
@@ -5,12 +5,14 @@ import type { EnsureEvoluOwnerDep } from '@minimalist-apps/evolu';
 import {
     createEnsureEvoluStorage,
     type EnsureEvoluStorageDep,
+    type GetEvoluRelayUrlsDep,
     type OnOwnerUsedDep,
 } from './createEnsureEvoluStorage';
 import { createEvoluFactory } from './createEvoluFactory';
 import { createEvoluStorageFactory } from './createEvoluStorageFactory';
 
 type CreateEvoluCompositionRootDeps<S extends EvoluSchema> = EnsureEvoluOwnerDep &
+    GetEvoluRelayUrlsDep &
     OnOwnerUsedDep & {
         readonly schema: ValidateSchema<S> extends never ? S : ValidateSchema<S>;
         readonly appName: string;
@@ -27,6 +29,7 @@ export const createEvoluCompositionRoot = <S extends EvoluSchema>(
         deps: {
             createEvoluStorage,
             ensureEvoluOwner: deps.ensureEvoluOwner,
+            getEvoluRelayUrls: deps.getEvoluRelayUrls,
             onOwnerUsed: deps.onOwnerUsed,
         },
         schema: deps.schema,

--- a/packages/evolu/src/createEvoluFactory.ts
+++ b/packages/evolu/src/createEvoluFactory.ts
@@ -2,7 +2,6 @@ import {
     AppName,
     createAppOwner,
     createEvolu,
-    createOwnerWebSocketTransport,
     getOrThrow,
     type Mnemonic,
     mnemonicToOwnerSecret,
@@ -15,6 +14,7 @@ import type {
     Owner,
     ValidateSchema,
 } from '@evolu/common/local-first';
+import { createOwnerRelayController } from './createOwnerRelayController';
 
 type CreateEvoluProps<S extends EvoluSchema> = {
     readonly mnemonic: Mnemonic;
@@ -26,6 +26,7 @@ type CreateEvoluProps<S extends EvoluSchema> = {
 type CreateEvoluResult<S extends EvoluSchema> = {
     readonly evolu: Evolu<S>;
     readonly owner: Owner;
+    readonly updateRelayUrls: (relayUrls: ReadonlyArray<string>) => void;
 };
 
 export type CreateEvolu<S extends EvoluSchema> = (
@@ -46,16 +47,18 @@ export const createEvoluFactory =
             await deps.run(
                 createEvolu(props.schema, {
                     appName: AppName.orThrow(props.appName),
-                    transports: props.urls.map(url =>
-                        createOwnerWebSocketTransport({
-                            url,
-                            ownerId: owner.id,
-                        }),
-                    ),
+                    transports: [],
                     appOwner: owner,
                 }),
             ),
         );
 
-        return { evolu, owner };
+        const relayController = createOwnerRelayController({ evolu, owner });
+        relayController.updateRelayUrls(props.urls);
+
+        return {
+            evolu,
+            owner,
+            updateRelayUrls: relayController.updateRelayUrls,
+        };
     };

--- a/packages/evolu/src/createEvoluStorageFactory.ts
+++ b/packages/evolu/src/createEvoluStorageFactory.ts
@@ -43,13 +43,18 @@ export const createEvoluStorageFactory =
 
         let evolu = createdEvolu.evolu;
         let activeOwner = createdEvolu.owner;
+        let relayUrls = props.urls;
+        let updateActiveRelayUrls = createdEvolu.updateRelayUrls;
 
         props.onOwnerUsed?.(activeOwner);
 
         let isDisposed = false;
 
-        const updateRelayUrls = (/*urls?: ReadonlyArray<string>*/): Promise<void> =>
-            Promise.resolve();
+        const updateRelayUrls = (urls: ReadonlyArray<string>): Promise<void> =>
+            Promise.resolve().then(() => {
+                updateActiveRelayUrls(urls);
+                relayUrls = urls;
+            });
 
         const restoreOwner = async (mnemonic: Mnemonic): Promise<void> => {
             const previousEvolu = evolu;
@@ -58,10 +63,11 @@ export const createEvoluStorageFactory =
                 mnemonic,
                 schema: props.schema,
                 appName: props.appName,
-                urls: props.urls,
+                urls: relayUrls,
             });
             evolu = created.evolu;
             activeOwner = created.owner;
+            updateActiveRelayUrls = created.updateRelayUrls;
 
             props.onOwnerUsed?.(activeOwner);
             await disposeEvolu(previousEvolu);

--- a/packages/evolu/src/createOwnerRelayController.test.ts
+++ b/packages/evolu/src/createOwnerRelayController.test.ts
@@ -1,0 +1,60 @@
+import type { Evolu, Owner } from '@evolu/common';
+import { describe, expect, test, vi } from 'vitest';
+import { createOwnerRelayController } from './createOwnerRelayController';
+import type { TodoTestSchema } from './mockEvoluStorage';
+
+const owner = {
+    id: 'test-owner-id',
+} as Owner;
+
+describe(createOwnerRelayController.name, () => {
+    test('switches to all new relays before releasing the previous relays', () => {
+        const events: Array<string> = [];
+        const releaseFirst = vi.fn(() => events.push('release-first'));
+        const releaseSecond = vi.fn(() => events.push('release-second'));
+        const useOwner = vi
+            .fn()
+            .mockImplementationOnce(() => {
+                events.push('use-first');
+
+                return releaseFirst;
+            })
+            .mockImplementationOnce(() => {
+                events.push('use-second');
+
+                return releaseSecond;
+            });
+        const controller = createOwnerRelayController({
+            evolu: { useOwner } as unknown as Evolu<TodoTestSchema>,
+            owner,
+        });
+
+        controller.updateRelayUrls(['wss://one.example', 'wss://two.example']);
+        controller.updateRelayUrls(['wss://three.example']);
+
+        expect(useOwner).toHaveBeenNthCalledWith(1, owner, [
+            { type: 'WebSocket', url: 'wss://one.example?ownerId=test-owner-id' },
+            { type: 'WebSocket', url: 'wss://two.example?ownerId=test-owner-id' },
+        ]);
+        expect(useOwner).toHaveBeenNthCalledWith(2, owner, [
+            { type: 'WebSocket', url: 'wss://three.example?ownerId=test-owner-id' },
+        ]);
+        expect(events).toEqual(['use-first', 'use-second', 'release-first']);
+        expect(releaseSecond).not.toHaveBeenCalled();
+    });
+
+    test('releases active relays when given an empty list', () => {
+        const release = vi.fn();
+        const useOwner = vi.fn(() => release);
+        const controller = createOwnerRelayController({
+            evolu: { useOwner } as unknown as Evolu<TodoTestSchema>,
+            owner,
+        });
+
+        controller.updateRelayUrls(['wss://one.example']);
+        controller.updateRelayUrls([]);
+
+        expect(release).toHaveBeenCalledOnce();
+        expect(useOwner).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/evolu/src/createOwnerRelayController.ts
+++ b/packages/evolu/src/createOwnerRelayController.ts
@@ -1,0 +1,50 @@
+import {
+    createOwnerWebSocketTransport,
+    type Evolu,
+    type EvoluSchema,
+    type Owner,
+} from '@evolu/common';
+
+type CreateOwnerRelayControllerDeps<S extends EvoluSchema> = {
+    readonly evolu: Evolu<S>;
+    readonly owner: Owner;
+};
+
+export type OwnerRelayController = {
+    readonly updateRelayUrls: (relayUrls: ReadonlyArray<string>) => void;
+};
+
+export const createOwnerRelayController = <S extends EvoluSchema>(
+    deps: CreateOwnerRelayControllerDeps<S>,
+): OwnerRelayController => {
+    let releaseActiveRelays: (() => void) | null = null;
+
+    const updateRelayUrls = (relayUrls: ReadonlyArray<string>) => {
+        if (relayUrls.length === 0) {
+            releaseActiveRelays?.();
+            releaseActiveRelays = null;
+
+            return;
+        }
+
+        const [firstRelayUrl, ...remainingRelayUrls] = relayUrls;
+        const transports = [
+            createOwnerWebSocketTransport({
+                url: firstRelayUrl,
+                ownerId: deps.owner.id,
+            }),
+            ...remainingRelayUrls.map(url =>
+                createOwnerWebSocketTransport({
+                    url,
+                    ownerId: deps.owner.id,
+                }),
+            ),
+        ] as const;
+
+        const releasePreviousRelays = releaseActiveRelays;
+        releaseActiveRelays = deps.evolu.useOwner(deps.owner, transports);
+        releasePreviousRelays?.();
+    };
+
+    return { updateRelayUrls };
+};

--- a/packages/evolu/src/index.ts
+++ b/packages/evolu/src/index.ts
@@ -6,9 +6,15 @@ export {
 export {
     createEnsureEvoluStorage,
     type EnsureEvoluStorageDep,
+    type GetEvoluRelayUrlsDep,
     type OnOwnerUsedDep,
 } from './createEnsureEvoluStorage';
 export { createEvoluCompositionRoot } from './createEvoluCompositionRoot';
 export { createSubscribableQuery } from './createSubscribableQuery';
 export type { EvoluStorage } from './EvoluStorage';
 export { installPolyfills } from './installPolyfills';
+export {
+    DEFAULT_EVOLU_RELAY_URLS,
+    type EvoluRelayUrlsValidationError,
+    parseEvoluRelayUrls,
+} from './parseEvoluRelayUrls';

--- a/packages/evolu/src/parseEvoluRelayUrls.test.ts
+++ b/packages/evolu/src/parseEvoluRelayUrls.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+import { parseEvoluRelayUrls } from './parseEvoluRelayUrls';
+
+describe(parseEvoluRelayUrls.name, () => {
+    test('parses, trims, and deduplicates relay URLs while preserving their order', () => {
+        const result = parseEvoluRelayUrls(`
+            wss://relay-one.example
+            ws://localhost:4000/sync
+            wss://relay-one.example
+        `);
+
+        expect(result).toEqual({
+            ok: true,
+            value: ['wss://relay-one.example', 'ws://localhost:4000/sync'],
+        });
+    });
+
+    test.each([
+        ['', 'an empty list'],
+        ['https://relay.example', 'a non-WebSocket URL'],
+        ['wss://relay.example?token=secret', 'a URL with a query'],
+        ['wss://relay.example#fragment', 'a URL with a fragment'],
+        ['wss://user:secret@relay.example', 'a URL with credentials'],
+        ['not a URL', 'an invalid URL'],
+    ])('rejects %s (%s)', input => {
+        expect(parseEvoluRelayUrls(input).ok).toBe(false);
+    });
+});

--- a/packages/evolu/src/parseEvoluRelayUrls.ts
+++ b/packages/evolu/src/parseEvoluRelayUrls.ts
@@ -1,0 +1,57 @@
+import { err, ok, type Result } from '@evolu/common';
+
+export const DEFAULT_EVOLU_RELAY_URLS: ReadonlyArray<string> = ['wss://free.evoluhq.com'];
+
+export type EvoluRelayUrlsValidationError = {
+    readonly message: string;
+};
+
+const invalidRelayUrl = (message: string): Result<never, EvoluRelayUrlsValidationError> =>
+    err({ message });
+
+export const parseEvoluRelayUrls = (
+    input: string,
+): Result<ReadonlyArray<string>, EvoluRelayUrlsValidationError> => {
+    const relayUrls = input
+        .split(/\r?\n/u)
+        .map(url => url.trim())
+        .filter(url => url !== '');
+
+    if (relayUrls.length === 0) {
+        return invalidRelayUrl('Configure at least one relay.');
+    }
+
+    const canonicalUrls = new Set<string>();
+    const uniqueRelayUrls: Array<string> = [];
+
+    for (const relayUrl of relayUrls) {
+        let parsedUrl: URL;
+
+        try {
+            parsedUrl = new URL(relayUrl);
+        } catch {
+            return invalidRelayUrl(`Invalid relay URL: ${relayUrl}`);
+        }
+
+        if (parsedUrl.protocol !== 'ws:' && parsedUrl.protocol !== 'wss:') {
+            return invalidRelayUrl(`Relay URL must use ws:// or wss://: ${relayUrl}`);
+        }
+
+        if (parsedUrl.search !== '' || parsedUrl.hash !== '') {
+            return invalidRelayUrl(`Relay URL cannot contain a query or fragment: ${relayUrl}`);
+        }
+
+        if (parsedUrl.username !== '' || parsedUrl.password !== '') {
+            return invalidRelayUrl(`Relay URL cannot contain credentials: ${relayUrl}`);
+        }
+
+        if (canonicalUrls.has(parsedUrl.href)) {
+            continue;
+        }
+
+        canonicalUrls.add(parsedUrl.href);
+        uniqueRelayUrls.push(relayUrl);
+    }
+
+    return ok(uniqueRelayUrls);
+};

--- a/packages/fragment-evolu/src/EvoluRelaySettings.test.tsx
+++ b/packages/fragment-evolu/src/EvoluRelaySettings.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import {
+    EVOLU_RELAY_SETTINGS_SAVE_BUTTON,
+    EVOLU_RELAY_SETTINGS_TEXTAREA,
+    EvoluRelaySettingsPure,
+} from './EvoluRelaySettings';
+
+describe(EvoluRelaySettingsPure.name, () => {
+    test('shows all configured relays', () => {
+        const setEvoluRelayUrls = vi.fn();
+        const Component = () =>
+            EvoluRelaySettingsPure(
+                { setEvoluRelayUrls },
+                { evoluRelayUrls: ['wss://one.example', 'wss://two.example'] },
+            );
+
+        render(<Component />);
+
+        expect(
+            (screen.getByTestId(EVOLU_RELAY_SETTINGS_TEXTAREA) as HTMLTextAreaElement).value,
+        ).toBe('wss://one.example\nwss://two.example');
+    });
+
+    test('saves a validated list of relays', async () => {
+        const setEvoluRelayUrls = vi.fn().mockResolvedValue(undefined);
+        const Component = () =>
+            EvoluRelaySettingsPure(
+                { setEvoluRelayUrls },
+                { evoluRelayUrls: ['wss://one.example'] },
+            );
+
+        render(<Component />);
+
+        const textarea = screen.getByTestId(EVOLU_RELAY_SETTINGS_TEXTAREA);
+        fireEvent.change(textarea, {
+            target: { value: 'wss://two.example\nwss://three.example' },
+        });
+        fireEvent.click(screen.getByTestId(EVOLU_RELAY_SETTINGS_SAVE_BUTTON));
+
+        await waitFor(() => {
+            expect(setEvoluRelayUrls).toHaveBeenCalledWith([
+                'wss://two.example',
+                'wss://three.example',
+            ]);
+        });
+    });
+
+    test('does not allow an invalid relay URL to be saved', () => {
+        const setEvoluRelayUrls = vi.fn();
+        const Component = () =>
+            EvoluRelaySettingsPure(
+                { setEvoluRelayUrls },
+                { evoluRelayUrls: ['wss://one.example'] },
+            );
+
+        render(<Component />);
+
+        const textarea = screen.getByTestId(EVOLU_RELAY_SETTINGS_TEXTAREA);
+        fireEvent.change(textarea, {
+            target: { value: 'https://not-a-websocket.example' },
+        });
+
+        expect(
+            (screen.getByTestId(EVOLU_RELAY_SETTINGS_SAVE_BUTTON) as HTMLButtonElement).disabled,
+        ).toBe(true);
+        expect(setEvoluRelayUrls).not.toHaveBeenCalled();
+    });
+});

--- a/packages/fragment-evolu/src/EvoluRelaySettings.tsx
+++ b/packages/fragment-evolu/src/EvoluRelaySettings.tsx
@@ -1,0 +1,91 @@
+import { Banner, Button, Column, Row, SettingsRow, Textarea } from '@minimalist-apps/components';
+import { parseEvoluRelayUrls } from '@minimalist-apps/evolu';
+import type { FC } from 'react';
+import { useState } from 'react';
+import type { SetEvoluRelayUrlsDep } from './createSetEvoluRelayUrls';
+
+export const EVOLU_RELAY_SETTINGS_TEXTAREA = 'EVOLU_RELAY_SETTINGS_TEXTAREA';
+export const EVOLU_RELAY_SETTINGS_SAVE_BUTTON = 'EVOLU_RELAY_SETTINGS_SAVE_BUTTON';
+
+type EvoluRelaySettingsStateProps = {
+    readonly evoluRelayUrls: ReadonlyArray<string>;
+};
+
+export type EvoluRelaySettingsDep = {
+    readonly EvoluRelaySettings: FC;
+};
+
+type SaveState = 'idle' | 'saving' | 'failed';
+
+export const EvoluRelaySettingsPure = (
+    deps: SetEvoluRelayUrlsDep,
+    { evoluRelayUrls }: EvoluRelaySettingsStateProps,
+) => {
+    const [draft, setDraft] = useState(evoluRelayUrls.join('\n'));
+    const [saveState, setSaveState] = useState<SaveState>('idle');
+    const parsedRelayUrls = parseEvoluRelayUrls(draft);
+    const currentRelayUrls = evoluRelayUrls.join('\n');
+    const parsedDraft = parsedRelayUrls.ok ? parsedRelayUrls.value.join('\n') : null;
+    const hasChanges = parsedDraft !== null && parsedDraft !== currentRelayUrls;
+
+    const handleDraftChange = (value: string) => {
+        setDraft(value);
+        setSaveState('idle');
+    };
+
+    const handleSave = () => {
+        if (!parsedRelayUrls.ok || saveState === 'saving') {
+            return;
+        }
+
+        setSaveState('saving');
+        void deps.setEvoluRelayUrls(parsedRelayUrls.value).then(
+            () => {
+                setDraft(parsedRelayUrls.value.join('\n'));
+                setSaveState('idle');
+            },
+            () => {
+                setSaveState('failed');
+            },
+        );
+    };
+
+    const validationError = parsedRelayUrls.ok ? null : parsedRelayUrls.error.message;
+
+    return (
+        <SettingsRow
+            label="Sync Relays"
+            description="Enter one WebSocket relay URL per line. Two independent relays are recommended."
+            direction="column"
+        >
+            <Column gap={12}>
+                <Textarea
+                    value={draft}
+                    onChange={handleDraftChange}
+                    rows={4}
+                    disabled={saveState === 'saving'}
+                    {...(validationError !== null || saveState === 'failed'
+                        ? { status: 'error' as const }
+                        : {})}
+                    testId={EVOLU_RELAY_SETTINGS_TEXTAREA}
+                />
+                {validationError !== null ? (
+                    <Banner intent="danger">{validationError}</Banner>
+                ) : null}
+                {saveState === 'failed' ? (
+                    <Banner intent="danger">Could not update the sync relays. Try again.</Banner>
+                ) : null}
+                <Row justify="end">
+                    <Button
+                        onClick={handleSave}
+                        loading={saveState === 'saving'}
+                        disabled={!hasChanges || validationError !== null}
+                        testId={EVOLU_RELAY_SETTINGS_SAVE_BUTTON}
+                    >
+                        Save Relays
+                    </Button>
+                </Row>
+            </Column>
+        </SettingsRow>
+    );
+};

--- a/packages/fragment-evolu/src/createEvoluFragmentCompositionRoot.ts
+++ b/packages/fragment-evolu/src/createEvoluFragmentCompositionRoot.ts
@@ -15,6 +15,8 @@ import {
 } from './createRestoreMnemonic';
 import { createSetActiveOwnerAppId } from './createSetActiveOwnerAppId';
 import { createSetEvoluMnemonic } from './createSetEvoluMnemonic';
+import { createSetEvoluRelayUrls } from './createSetEvoluRelayUrls';
+import { type EvoluRelaySettingsDep, EvoluRelaySettingsPure } from './EvoluRelaySettings';
 import type { EvoluState, EvoluStoreDep } from './evoluState';
 import { type RestoreMnemonicDep, RestoreMnemonic as RestoreMnemonicPure } from './RestoreMnemonic';
 import { selectEvoluMnemonic } from './selectEvoluMnemonic';
@@ -28,6 +30,7 @@ type EvoluFragmentCompositionRootDeps<Schema extends EvoluSchema> = EvoluStoreDe
 
 type EvoluFragment<Schema extends EvoluSchema> = BackupMnemonicDep &
     RestoreMnemonicDep &
+    EvoluRelaySettingsDep &
     RestoreMnemonicServiceDep &
     EnsureEvoluStorageDep<Schema>;
 
@@ -50,6 +53,7 @@ export const createEvoluFragmentCompositionRoot = <Schema extends EvoluSchema>(
 
     const { ensureEvoluStorage } = createEvoluCompositionRoot<Schema>({
         ensureEvoluOwner,
+        getEvoluRelayUrls: () => deps.store.getState().evoluRelayUrls,
         onOwnerUsed: owner => setActiveOwnerAppId(owner.id),
         schema: deps.schema,
         appName: deps.appName,
@@ -57,6 +61,10 @@ export const createEvoluFragmentCompositionRoot = <Schema extends EvoluSchema>(
 
     const restoreMnemonic = createRestoreMnemonic({
         setEvoluMnemonic,
+        ensureEvoluStorage,
+    });
+    const setEvoluRelayUrls = createSetEvoluRelayUrls({
+        store: deps.store,
         ensureEvoluStorage,
     });
 
@@ -74,5 +82,17 @@ export const createEvoluFragmentCompositionRoot = <Schema extends EvoluSchema>(
         restoreMnemonic,
     });
 
-    return { BackupMnemonic, RestoreMnemonic, restoreMnemonic, ensureEvoluStorage };
+    const EvoluRelaySettings = deps.connect(
+        EvoluRelaySettingsPure,
+        ({ store }) => ({ evoluRelayUrls: store.evoluRelayUrls }),
+        { setEvoluRelayUrls },
+    );
+
+    return {
+        BackupMnemonic,
+        RestoreMnemonic,
+        EvoluRelaySettings,
+        restoreMnemonic,
+        ensureEvoluStorage,
+    };
 };

--- a/packages/fragment-evolu/src/createSetEvoluMnemonic.test.ts
+++ b/packages/fragment-evolu/src/createSetEvoluMnemonic.test.ts
@@ -9,7 +9,11 @@ const mnemonic = Mnemonic.orThrow(
 );
 
 const createEvoluStore = () =>
-    createStore<EvoluState>({ evoluMnemonic: null, activeOwnerAppId: null });
+    createStore<EvoluState>({
+        evoluMnemonic: null,
+        activeOwnerAppId: null,
+        evoluRelayUrls: ['wss://free.evoluhq.com'],
+    });
 
 describe(createSetEvoluMnemonic.name, () => {
     test('updates state only after secure persistence succeeds', async () => {

--- a/packages/fragment-evolu/src/createSetEvoluRelayUrls.test.ts
+++ b/packages/fragment-evolu/src/createSetEvoluRelayUrls.test.ts
@@ -1,0 +1,47 @@
+import type { EvoluSchema } from '@evolu/common';
+import { createStore } from '@minimalist-apps/mini-store';
+import { describe, expect, test, vi } from 'vitest';
+import { createSetEvoluRelayUrls } from './createSetEvoluRelayUrls';
+import type { EvoluState } from './evoluState';
+
+const initialState: EvoluState = {
+    evoluMnemonic: null,
+    activeOwnerAppId: null,
+    evoluRelayUrls: ['wss://free.evoluhq.com'],
+};
+
+describe(createSetEvoluRelayUrls.name, () => {
+    test('updates live transports before publishing the new setting', async () => {
+        const store = createStore(initialState);
+        const updateRelayUrls = vi.fn(() => {
+            expect(store.getState().evoluRelayUrls).toEqual(['wss://free.evoluhq.com']);
+
+            return Promise.resolve();
+        });
+        const setEvoluRelayUrls = createSetEvoluRelayUrls<EvoluSchema>({
+            store,
+            ensureEvoluStorage: async () => ({ updateRelayUrls }) as never,
+        });
+        const relayUrls = ['wss://one.example', 'wss://two.example'];
+
+        await setEvoluRelayUrls(relayUrls);
+
+        expect(updateRelayUrls).toHaveBeenCalledWith(relayUrls);
+        expect(store.getState().evoluRelayUrls).toEqual(relayUrls);
+    });
+
+    test('keeps the previous setting when updating live transports fails', async () => {
+        const store = createStore(initialState);
+        const updateError = new Error('transport failed');
+        const setEvoluRelayUrls = createSetEvoluRelayUrls<EvoluSchema>({
+            store,
+            ensureEvoluStorage: async () =>
+                ({
+                    updateRelayUrls: vi.fn().mockRejectedValue(updateError),
+                }) as never,
+        });
+
+        await expect(setEvoluRelayUrls(['wss://one.example'])).rejects.toBe(updateError);
+        expect(store.getState()).toEqual(initialState);
+    });
+});

--- a/packages/fragment-evolu/src/createSetEvoluRelayUrls.ts
+++ b/packages/fragment-evolu/src/createSetEvoluRelayUrls.ts
@@ -1,0 +1,19 @@
+import type { EvoluSchema } from '@evolu/common';
+import type { EnsureEvoluStorageDep } from '@minimalist-apps/evolu';
+import type { EvoluStoreDep } from './evoluState';
+
+type SetEvoluRelayUrlsDeps<S extends EvoluSchema> = EvoluStoreDep & EnsureEvoluStorageDep<S>;
+
+export type SetEvoluRelayUrls = (relayUrls: ReadonlyArray<string>) => Promise<void>;
+
+export type SetEvoluRelayUrlsDep = {
+    readonly setEvoluRelayUrls: SetEvoluRelayUrls;
+};
+
+export const createSetEvoluRelayUrls =
+    <S extends EvoluSchema>(deps: SetEvoluRelayUrlsDeps<S>): SetEvoluRelayUrls =>
+    async relayUrls => {
+        const evoluStorage = await deps.ensureEvoluStorage();
+        await evoluStorage.updateRelayUrls(relayUrls);
+        deps.store.setState({ evoluRelayUrls: relayUrls });
+    };

--- a/packages/fragment-evolu/src/evoluState.ts
+++ b/packages/fragment-evolu/src/evoluState.ts
@@ -4,6 +4,7 @@ import type { Store } from '@minimalist-apps/mini-store';
 export interface EvoluState {
     readonly evoluMnemonic: Mnemonic | null;
     readonly activeOwnerAppId: OwnerId | null;
+    readonly evoluRelayUrls: ReadonlyArray<string>;
 }
 
 export type EvoluStoreDep = {

--- a/packages/fragment-evolu/src/index.ts
+++ b/packages/fragment-evolu/src/index.ts
@@ -11,6 +11,17 @@ export type { SetActiveOwnerAppIdDep } from './createSetActiveOwnerAppId';
 export { createSetActiveOwnerAppId } from './createSetActiveOwnerAppId';
 export type { SetEvoluMnemonicDep } from './createSetEvoluMnemonic';
 export { createSetEvoluMnemonic } from './createSetEvoluMnemonic';
+export {
+    createSetEvoluRelayUrls,
+    type SetEvoluRelayUrls,
+    type SetEvoluRelayUrlsDep,
+} from './createSetEvoluRelayUrls';
+export {
+    EVOLU_RELAY_SETTINGS_SAVE_BUTTON,
+    EVOLU_RELAY_SETTINGS_TEXTAREA,
+    type EvoluRelaySettingsDep,
+    EvoluRelaySettingsPure,
+} from './EvoluRelaySettings';
 export type { EvoluState } from './evoluState';
 export type { RestoreMnemonicDep } from './RestoreMnemonic';
 export { RestoreMnemonic } from './RestoreMnemonic';

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,10 +2,10 @@
 import '@testing-library/jest-dom/vitest';
 import { vi } from 'vitest';
 
-const testCreateResizeObserver = vi.fn(() => ({
-    disconnect: vi.fn(),
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-}));
+class TestResizeObserver {
+    readonly disconnect = vi.fn();
+    readonly observe = vi.fn();
+    readonly unobserve = vi.fn();
+}
 
-vi.stubGlobal('ResizeObserver', testCreateResizeObserver);
+vi.stubGlobal('ResizeObserver', TestResizeObserver);


### PR DESCRIPTION
## Summary

- add shared Evolu relay settings to Android Sync, Chat, and Price Converter
- accept, validate, deduplicate, and persist multiple `ws://` or `wss://` relay URLs
- load configured relays before Evolu starts and keep them when restoring an owner
- swap owner transports live without replacing the Evolu database instance or query subscriptions
- use Evolu 8.5's `wss://free.evoluhq.com` default
- make the shared ResizeObserver test stub constructible for the new settings component tests

## Verification

- formatter and Biome/ESLint checks
- full workspace typecheck
- 79 test files / 379 tests
- Knip
- production builds for Android Sync, Chat, and Price Converter