### PR TITLE
Fix transactional Evolu owner restoration

### DIFF
--- a/apps/price-converter/src/converter/reorderCurrency.test.ts
+++ b/apps/price-converter/src/converter/reorderCurrency.test.ts
@@ -29,6 +29,7 @@ const mockEvoluStorage = (upsert: EvoluStorage['evolu']['upsert']): EvoluStorage
     activeOwner: { id: 'test-owner' } as Owner,
     updateRelayUrls: vi.fn(),
     restoreOwner: vi.fn(),
+    subscribeOwnerChange: vi.fn(() => () => {}),
     dispose: vi.fn(),
 });
 

--- a/apps/price-converter/src/state/addCurrency.test.ts
+++ b/apps/price-converter/src/state/addCurrency.test.ts
@@ -12,6 +12,7 @@ const mockEvoluStorage = (upsert: unknown): EvoluStorage => ({
     activeOwner: { id: 'test-owner' } as Owner,
     updateRelayUrls: vi.fn(),
     restoreOwner: vi.fn(),
+    subscribeOwnerChange: vi.fn(() => () => {}),
     dispose: vi.fn(),
 });
 

--- a/apps/price-converter/src/state/evolu/createSelectedCurrenciesStore.test.ts
+++ b/apps/price-converter/src/state/evolu/createSelectedCurrenciesStore.test.ts
@@ -1,8 +1,52 @@
+import { getOrThrow } from '@evolu/common';
+import { CurrencyCode } from '@minimalist-apps/fiat';
+import { asFractionalIndex } from '@minimalist-apps/fractional-indexing';
 import { describe, expect, test, vi } from 'vitest';
 import { createSelectedCurrenciesStore } from './createSelectedCurrenciesStore';
 
 // biome-ignore lint/suspicious/noExplicitAny: test mocks
 const asAny = <T>(value: T): any => value;
+
+const USD = getOrThrow(CurrencyCode.fromUnknown('USD'));
+const EUR = getOrThrow(CurrencyCode.fromUnknown('EUR'));
+
+const createMockEvolu = (initialCurrency: CurrencyCode) => {
+    let rows = [
+        {
+            id: `${initialCurrency}-id`,
+            currency: initialCurrency,
+            order: asFractionalIndex('a0'),
+        },
+    ];
+    let queryListener: (() => void) | undefined;
+    const evolu = {
+        subscribeQuery: vi.fn(() => (listener: () => void) => {
+            queryListener = listener;
+
+            return () => {
+                if (queryListener === listener) {
+                    queryListener = undefined;
+                }
+            };
+        }),
+        loadQuery: vi.fn(() => Promise.resolve(rows)),
+        getQueryRows: vi.fn(() => rows),
+    };
+
+    return {
+        evolu,
+        emitCurrency: (currency: CurrencyCode) => {
+            rows = [
+                {
+                    id: `${currency}-id`,
+                    currency,
+                    order: asFractionalIndex('a0'),
+                },
+            ];
+            queryListener?.();
+        },
+    };
+};
 
 describe('createSelectedCurrenciesStore', () => {
     test('defers ensureEvoluStorage call to subscribe/getState time', () => {
@@ -26,6 +70,7 @@ describe('createSelectedCurrenciesStore', () => {
         const storage = {
             evolu,
             activeOwner: { id: 'owner-id' },
+            subscribeOwnerChange: vi.fn(() => () => {}),
         };
         const ensureEvoluStorage = vi.fn(() => Promise.resolve(asAny(storage)));
         const selectedCurrenciesStore = createSelectedCurrenciesStore({
@@ -35,5 +80,49 @@ describe('createSelectedCurrenciesStore', () => {
         selectedCurrenciesStore.subscribe(vi.fn());
 
         expect(ensureEvoluStorage).toHaveBeenCalledOnce();
+    });
+
+    test('switches to restored owner currencies and keeps receiving their updates', async () => {
+        const first = createMockEvolu(USD);
+        const restored = createMockEvolu(EUR);
+        const ownerChangeListeners = new Set<() => void>();
+        let active = { evolu: first.evolu, ownerId: 'first-owner' };
+        const storage = {
+            get evolu() {
+                return active.evolu;
+            },
+            get activeOwner() {
+                return { id: active.ownerId };
+            },
+            subscribeOwnerChange: (listener: () => void) => {
+                ownerChangeListeners.add(listener);
+
+                return () => {
+                    ownerChangeListeners.delete(listener);
+                };
+            },
+        };
+        const selectedCurrenciesStore = createSelectedCurrenciesStore({
+            ensureEvoluStorage: () => Promise.resolve(asAny(storage)),
+        });
+        selectedCurrenciesStore.subscribe(vi.fn());
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(selectedCurrenciesStore.getState().map(currency => currency.code)).toEqual([USD]);
+
+        active = { evolu: restored.evolu, ownerId: 'restored-owner' };
+
+        for (const listener of ownerChangeListeners) {
+            listener();
+        }
+
+        expect(selectedCurrenciesStore.getState().map(currency => currency.code)).toEqual([EUR]);
+
+        restored.emitCurrency(USD);
+        expect(selectedCurrenciesStore.getState().map(currency => currency.code)).toEqual([USD]);
+
+        first.emitCurrency(EUR);
+        expect(selectedCurrenciesStore.getState().map(currency => currency.code)).toEqual([USD]);
     });
 });

--- a/packages/components/src/Banner.tsx
+++ b/packages/components/src/Banner.tsx
@@ -8,6 +8,7 @@ interface BannerProps {
     readonly intent?: Intent;
     readonly showIcon?: boolean;
     readonly style?: React.CSSProperties;
+    readonly testId?: string;
 }
 
 const buildBannerType = (intent: Intent | undefined): 'info' | 'warning' | 'error' => {
@@ -28,11 +29,12 @@ const buildBannerType = (intent: Intent | undefined): 'info' | 'warning' | 'erro
     }
 };
 
-export const Banner = ({ children, intent, showIcon = true, style }: BannerProps) => (
+export const Banner = ({ children, intent, showIcon = true, style, testId }: BannerProps) => (
     <Alert
         {...(children !== undefined ? { description: children } : {})}
         type={buildBannerType(intent)}
         showIcon={showIcon}
         {...(style !== undefined ? { style } : {})}
+        {...(testId !== undefined ? { id: testId, 'data-testid': testId } : {})}
     />
 );

--- a/packages/components/src/Modal.tsx
+++ b/packages/components/src/Modal.tsx
@@ -11,6 +11,7 @@ interface ModalProps {
     readonly cancelText?: string;
     readonly okDanger?: boolean;
     readonly okDisabled?: boolean;
+    readonly okLoading?: boolean;
     readonly centered?: boolean;
     readonly showCancel?: boolean;
     readonly closable?: boolean;
@@ -32,6 +33,7 @@ export const Modal = ({
     cancelText,
     okDanger = false,
     okDisabled = false,
+    okLoading = false,
     centered = false,
     showCancel = true,
     closable = true,
@@ -62,6 +64,7 @@ export const Modal = ({
         okButtonProps={{
             ...(okDanger ? { danger: true } : {}),
             ...(okDisabled ? { disabled: true } : {}),
+            ...(okLoading ? { loading: true } : {}),
             ...(okButtonTestId !== undefined ? { id: okButtonTestId } : {}),
             ...(okButtonTestId !== undefined ? { 'data-testid': okButtonTestId } : {}),
             style: { boxShadow: 'none' },

--- a/packages/evolu/src/EvoluStorage.ts
+++ b/packages/evolu/src/EvoluStorage.ts
@@ -1,9 +1,15 @@
 import type { Evolu, EvoluSchema, Mnemonic, Owner } from '@evolu/common';
 
+export type RestoreOwnerParams = {
+    readonly mnemonic: Mnemonic;
+    readonly persistMnemonic: () => Promise<void>;
+};
+
 export type EvoluStorage<S extends EvoluSchema> = {
     readonly evolu: Evolu<S>;
     readonly activeOwner: Owner;
     readonly updateRelayUrls: (urls: ReadonlyArray<string>) => Promise<void>;
-    readonly restoreOwner: (mnemonic: Mnemonic) => Promise<void>;
+    readonly restoreOwner: (params: RestoreOwnerParams) => Promise<void>;
+    readonly subscribeOwnerChange: (listener: () => void) => () => void;
     readonly dispose: () => Promise<void>;
 };

--- a/packages/evolu/src/createEvoluStorageFactory.test.ts
+++ b/packages/evolu/src/createEvoluStorageFactory.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
 
+import type { Evolu, Owner } from '@evolu/common';
 import { Mnemonic } from '@evolu/common';
-import { describe, expect, test } from 'vitest';
-import { createEvoluFactory } from './createEvoluFactory';
+import { describe, expect, test, vi } from 'vitest';
+import { type CreateEvolu, createEvoluFactory } from './createEvoluFactory';
 import { createEvoluStorageFactory } from './createEvoluStorageFactory';
 import { TodoTestSchema } from './mockEvoluStorage';
 import { testCreateRunWithEvoluDeps } from './testCreateRunWithEvoluDeps';
@@ -28,14 +29,80 @@ describe(createEvoluStorageFactory.name, () => {
         const firstEvolu = storage.evolu;
         expect(storage.activeOwner.id).toBe('F0xh0HpiAx5shgCgtGENww');
 
-        await storage.restoreOwner(
-            Mnemonic.orThrow(
+        await storage.restoreOwner({
+            mnemonic: Mnemonic.orThrow(
                 'legal winner thank year wave sausage worth useful legal winner thank yellow',
             ),
-        );
+            persistMnemonic: () => Promise.resolve(),
+        });
 
         expect(storage.evolu).not.toBe(firstEvolu);
         expect(storage.activeOwner.id).toBe('9ac66DowyF8lV0ioma5_2Q');
+
+        await storage.dispose();
+    });
+
+    test('rolls back the active owner when mnemonic persistence fails', async () => {
+        const events: Array<string> = [];
+        const createFakeEvolu = (ownerId: string) => {
+            const evolu = {
+                [Symbol.asyncDispose]: vi.fn(() => {
+                    events.push(`dispose:${ownerId}`);
+
+                    return Promise.resolve();
+                }),
+            } as unknown as Evolu<TodoTestSchema>;
+
+            return {
+                evolu,
+                owner: { id: ownerId } as Owner,
+                updateRelayUrls: vi.fn(),
+            };
+        };
+        const first = createFakeEvolu('first-owner');
+        const candidate = createFakeEvolu('candidate-owner');
+        const createEvolu = vi
+            .fn()
+            .mockResolvedValueOnce(first)
+            .mockResolvedValueOnce(candidate) as unknown as CreateEvolu<TodoTestSchema>;
+        const storage = await createEvoluStorageFactory<TodoTestSchema>({ createEvolu })({
+            mnemonic: Mnemonic.orThrow(
+                'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+            ),
+            schema: TodoTestSchema,
+            appName: 'minimalist-apps-test',
+            urls: [],
+            onOwnerUsed: owner => events.push(`owner:${owner.id}`),
+        });
+        storage.subscribeOwnerChange(() => events.push('owner-change'));
+        const persistenceError = new Error('secure storage failed');
+
+        await expect(
+            storage.restoreOwner({
+                mnemonic: Mnemonic.orThrow(
+                    'legal winner thank year wave sausage worth useful legal winner thank yellow',
+                ),
+                persistMnemonic: () => {
+                    events.push(`persist:${storage.activeOwner.id}`);
+
+                    return Promise.reject(persistenceError);
+                },
+            }),
+        ).rejects.toBe(persistenceError);
+
+        expect(storage.evolu).toBe(first.evolu);
+        expect(storage.activeOwner).toBe(first.owner);
+        expect(first.evolu[Symbol.asyncDispose]).not.toHaveBeenCalled();
+        expect(candidate.evolu[Symbol.asyncDispose]).toHaveBeenCalledOnce();
+        expect(events).toEqual([
+            'owner:first-owner',
+            'owner:candidate-owner',
+            'owner-change',
+            'persist:candidate-owner',
+            'owner:first-owner',
+            'owner-change',
+            'dispose:candidate-owner',
+        ]);
 
         await storage.dispose();
     });

--- a/packages/evolu/src/createEvoluStorageFactory.ts
+++ b/packages/evolu/src/createEvoluStorageFactory.ts
@@ -1,7 +1,7 @@
 import type { Mnemonic } from '@evolu/common';
 import type { Evolu, EvoluSchema, Owner, ValidateSchema } from '@evolu/common/local-first';
 import type { CreateEvolu } from './createEvoluFactory';
-import type { EvoluStorage } from './EvoluStorage';
+import type { EvoluStorage, RestoreOwnerParams } from './EvoluStorage';
 
 type CreateEvoluStorageFactoryDeps<S extends EvoluSchema> = {
     readonly createEvolu: CreateEvolu<S>;
@@ -45,6 +45,7 @@ export const createEvoluStorageFactory =
         let activeOwner = createdEvolu.owner;
         let relayUrls = props.urls;
         let updateActiveRelayUrls = createdEvolu.updateRelayUrls;
+        const ownerChangeListeners = new Set<() => void>();
 
         props.onOwnerUsed?.(activeOwner);
 
@@ -56,21 +57,46 @@ export const createEvoluStorageFactory =
                 relayUrls = urls;
             });
 
-        const restoreOwner = async (mnemonic: Mnemonic): Promise<void> => {
-            const previousEvolu = evolu;
+        const notifyOwnerChange = () => {
+            for (const listener of ownerChangeListeners) {
+                listener();
+            }
+        };
 
-            const created = await deps.createEvolu({
-                mnemonic,
+        const activateOwner = (created: Awaited<ReturnType<CreateEvolu<S>>>) => {
+            evolu = created.evolu;
+            activeOwner = created.owner;
+            updateActiveRelayUrls = created.updateRelayUrls;
+            props.onOwnerUsed?.(activeOwner);
+            notifyOwnerChange();
+        };
+
+        const restoreOwner = async (params: RestoreOwnerParams): Promise<void> => {
+            const previous = {
+                evolu,
+                owner: activeOwner,
+                updateRelayUrls: updateActiveRelayUrls,
+            };
+            const candidate = await deps.createEvolu({
+                mnemonic: params.mnemonic,
                 schema: props.schema,
                 appName: props.appName,
                 urls: relayUrls,
             });
-            evolu = created.evolu;
-            activeOwner = created.owner;
-            updateActiveRelayUrls = created.updateRelayUrls;
 
-            props.onOwnerUsed?.(activeOwner);
-            await disposeEvolu(previousEvolu);
+            try {
+                activateOwner(candidate);
+                await params.persistMnemonic();
+            } catch (error) {
+                try {
+                    activateOwner(previous);
+                } finally {
+                    await disposeEvolu(candidate.evolu);
+                }
+                throw error;
+            }
+
+            await disposeEvolu(previous.evolu);
         };
 
         return {
@@ -82,6 +108,13 @@ export const createEvoluStorageFactory =
             },
             updateRelayUrls,
             restoreOwner,
+            subscribeOwnerChange: listener => {
+                ownerChangeListeners.add(listener);
+
+                return () => {
+                    ownerChangeListeners.delete(listener);
+                };
+            },
             dispose: async () => {
                 if (isDisposed) {
                     return;

--- a/packages/evolu/src/createSubscribableQuery.test.ts
+++ b/packages/evolu/src/createSubscribableQuery.test.ts
@@ -48,4 +48,55 @@ describe(createSubscribableQuery.name, () => {
         expect(listener).toHaveBeenCalled();
         expect(subscribable.getState()).toEqual([{ id: 'todo-2', value: 'walk dog' }]);
     });
+
+    test('rebinds to the restored owner and ignores stale owner updates', async () => {
+        const firstStorage = mockEvoluStorage([{ id: 'old', value: 'old owner' }]);
+        const secondStorage = mockEvoluStorage([{ id: 'new', value: 'new owner' }]);
+        const ownerChangeListeners = new Set<() => void>();
+        let activeStorage = firstStorage;
+        const storage: EvoluStorage<TodoTestSchema> = {
+            get evolu() {
+                return activeStorage.evolu;
+            },
+            get activeOwner() {
+                return activeStorage.activeOwner;
+            },
+            subscribeOwnerChange: (listener: () => void) => {
+                ownerChangeListeners.add(listener);
+
+                return () => {
+                    ownerChangeListeners.delete(listener);
+                };
+            },
+            updateRelayUrls: async () => {},
+            restoreOwner: async () => {},
+            dispose: async () => {},
+        };
+        const subscribable = createSubscribableQuery(
+            { ensureEvoluStorage: () => Promise.resolve(storage) },
+            () => query,
+            rows => rows,
+        );
+        const listener = vi.fn();
+        subscribable.subscribe(listener);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(subscribable.getState()).toEqual([{ id: 'old', value: 'old owner' }]);
+
+        activeStorage = secondStorage;
+
+        for (const ownerChangeListener of ownerChangeListeners) {
+            ownerChangeListener();
+        }
+        await Promise.resolve();
+
+        expect(subscribable.getState()).toEqual([{ id: 'new', value: 'new owner' }]);
+
+        secondStorage.emitUpdate([{ id: 'newer', value: 'new owner update' }]);
+        expect(subscribable.getState()).toEqual([{ id: 'newer', value: 'new owner update' }]);
+
+        firstStorage.emitUpdate([{ id: 'stale', value: 'stale owner update' }]);
+        expect(subscribable.getState()).toEqual([{ id: 'newer', value: 'new owner update' }]);
+    });
 });

--- a/packages/evolu/src/createSubscribableQuery.ts
+++ b/packages/evolu/src/createSubscribableQuery.ts
@@ -17,6 +17,8 @@ export const createSubscribableQuery = <S extends EvoluSchema, R extends Row, Ma
 ): Subscribable<ReadonlyArray<MappedRow>> => {
     let rows: ReadonlyArray<MappedRow> = [];
     let evoluUnsubscribe: (() => void) | null = null;
+    let ownerChangeUnsubscribe: (() => void) | null = null;
+    let bindingVersion = 0;
     let isInitializing = false;
     const listeners = new Set<() => void>();
 
@@ -27,7 +29,7 @@ export const createSubscribableQuery = <S extends EvoluSchema, R extends Row, Ma
     };
 
     const initialize = () => {
-        if (isInitializing || evoluUnsubscribe !== null) {
+        if (isInitializing || ownerChangeUnsubscribe !== null) {
             return;
         }
 
@@ -36,17 +38,30 @@ export const createSubscribableQuery = <S extends EvoluSchema, R extends Row, Ma
         void deps
             .ensureEvoluStorage()
             .then(storage => {
-                const query = queryFactory(storage);
+                const bindActiveOwner = () => {
+                    bindingVersion += 1;
+                    const currentBindingVersion = bindingVersion;
+                    const evolu = storage.evolu;
+                    const query = queryFactory(storage);
 
-                const refreshRows = () => {
-                    rows = mapRows(storage.evolu.getQueryRows(query));
-                    notifyListeners();
+                    const refreshRows = () => {
+                        if (currentBindingVersion !== bindingVersion) {
+                            return;
+                        }
+
+                        rows = mapRows(evolu.getQueryRows(query));
+                        notifyListeners();
+                    };
+
+                    evoluUnsubscribe?.();
+                    evoluUnsubscribe = evolu.subscribeQuery(query)(refreshRows);
+                    refreshRows();
+
+                    void evolu.loadQuery(query).then(refreshRows);
                 };
 
-                evoluUnsubscribe = storage.evolu.subscribeQuery(query)(refreshRows);
-                refreshRows();
-
-                void storage.evolu.loadQuery(query).then(refreshRows);
+                ownerChangeUnsubscribe = storage.subscribeOwnerChange(bindActiveOwner);
+                bindActiveOwner();
             })
             .finally(() => {
                 isInitializing = false;

--- a/packages/evolu/src/index.ts
+++ b/packages/evolu/src/index.ts
@@ -11,7 +11,7 @@ export {
 } from './createEnsureEvoluStorage';
 export { createEvoluCompositionRoot } from './createEvoluCompositionRoot';
 export { createSubscribableQuery } from './createSubscribableQuery';
-export type { EvoluStorage } from './EvoluStorage';
+export type { EvoluStorage, RestoreOwnerParams } from './EvoluStorage';
 export { installPolyfills } from './installPolyfills';
 export {
     DEFAULT_EVOLU_RELAY_URLS,

--- a/packages/evolu/src/mockEvoluStorage.ts
+++ b/packages/evolu/src/mockEvoluStorage.ts
@@ -43,6 +43,7 @@ export const mockEvoluStorage = (initialRows: ReadonlyArray<TodoRow>): MockEvolu
         activeOwner: { id: 'test-owner' } as EvoluStorage<TodoTestSchema>['activeOwner'],
         updateRelayUrls: async () => {},
         restoreOwner: async () => {},
+        subscribeOwnerChange: () => () => {},
         dispose: async () => {},
 
         emitUpdate: nextRows => {

--- a/packages/fragment-evolu/src/RestoreMnemonic.test.tsx
+++ b/packages/fragment-evolu/src/RestoreMnemonic.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import {
+    RESTORE_MNEMONIC_ERROR,
+    RESTORE_MNEMONIC_INPUT,
+    RESTORE_MNEMONIC_MODAL_OK,
+    RESTORE_MNEMONIC_OPEN_BUTTON,
+    RestoreMnemonic,
+} from './RestoreMnemonic';
+
+const validMnemonic = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+
+const createPendingPromise = () => {
+    let resolve: (() => void) | undefined;
+    let reject: ((error: unknown) => void) | undefined;
+    const promise = new Promise<void>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve;
+        reject = promiseReject;
+    });
+
+    return {
+        promise,
+        resolve: () => resolve?.(),
+        reject: (error: unknown) => reject?.(error),
+    };
+};
+
+const openAndFillRestoreModal = () => {
+    fireEvent.click(screen.getByTestId(RESTORE_MNEMONIC_OPEN_BUTTON));
+    fireEvent.change(screen.getByTestId(RESTORE_MNEMONIC_INPUT), {
+        target: { value: validMnemonic },
+    });
+};
+
+describe(RestoreMnemonic.name, () => {
+    test('prevents duplicate submits and closes only after restoration succeeds', async () => {
+        const pending = createPendingPromise();
+        const restoreMnemonic = vi.fn(() => pending.promise);
+        const Component = () => RestoreMnemonic({ restoreMnemonic });
+        render(<Component />);
+        openAndFillRestoreModal();
+
+        const okButton = screen.getByTestId(RESTORE_MNEMONIC_MODAL_OK) as HTMLButtonElement;
+        fireEvent.click(okButton);
+        fireEvent.click(okButton);
+
+        expect(restoreMnemonic).toHaveBeenCalledOnce();
+        expect(okButton.disabled).toBe(true);
+        expect(screen.getByTestId(RESTORE_MNEMONIC_INPUT)).not.toBeNull();
+
+        pending.resolve();
+
+        await waitFor(() => {
+            expect(screen.queryByTestId(RESTORE_MNEMONIC_INPUT)).toBeNull();
+        });
+
+        fireEvent.click(screen.getByTestId(RESTORE_MNEMONIC_OPEN_BUTTON));
+        expect((screen.getByTestId(RESTORE_MNEMONIC_INPUT) as HTMLTextAreaElement).value).toBe('');
+    });
+
+    test('keeps the modal open and reports restoration failures', async () => {
+        const pending = createPendingPromise();
+        const restoreMnemonic = vi.fn(() => pending.promise);
+        const Component = () => RestoreMnemonic({ restoreMnemonic });
+        render(<Component />);
+        openAndFillRestoreModal();
+
+        fireEvent.click(screen.getByTestId(RESTORE_MNEMONIC_MODAL_OK));
+        pending.reject(new Error('restore failed'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId(RESTORE_MNEMONIC_ERROR)).not.toBeNull();
+        });
+        expect((screen.getByTestId(RESTORE_MNEMONIC_INPUT) as HTMLTextAreaElement).value).toBe(
+            validMnemonic,
+        );
+    });
+});

--- a/packages/fragment-evolu/src/RestoreMnemonic.tsx
+++ b/packages/fragment-evolu/src/RestoreMnemonic.tsx
@@ -1,7 +1,7 @@
 import { Mnemonic } from '@evolu/common';
 import { Banner, Button, Column, Modal, SettingsRow, Textarea } from '@minimalist-apps/components';
 import type { FC } from 'react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { RestoreMnemonicDep as RestoreMnemonicServiceDep } from './createRestoreMnemonic';
 
 export type RestoreMnemonicDep = {
@@ -10,63 +10,114 @@ export type RestoreMnemonicDep = {
 
 type RestoreMnemonicDeps = RestoreMnemonicServiceDep;
 
+export const RESTORE_MNEMONIC_ERROR = 'RESTORE_MNEMONIC_ERROR';
+export const RESTORE_MNEMONIC_INPUT = 'restore-seed-input';
+export const RESTORE_MNEMONIC_MODAL_OK = 'restore-modal-ok';
+export const RESTORE_MNEMONIC_OPEN_BUTTON = 'restore-backup-button';
+
+type RestoreState = 'idle' | 'restoring' | 'failed';
+
 export const RestoreMnemonic = (deps: RestoreMnemonicDeps) => {
     const [isRestoreModalOpen, setIsRestoreModalOpen] = useState(false);
     const [restoreSeed, setRestoreSeed] = useState('');
+    const [restoreState, setRestoreState] = useState<RestoreState>('idle');
+    const isRestoringRef = useRef(false);
 
     const restoreResult = Mnemonic.fromUnknown(restoreSeed);
     const isRestoreSeedValid = restoreResult.ok === true;
 
     const openRestoreModal = () => {
+        setRestoreState('idle');
         setIsRestoreModalOpen(true);
     };
 
     const closeRestoreModal = () => {
+        if (isRestoringRef.current) {
+            return;
+        }
+
+        setRestoreState('idle');
         setIsRestoreModalOpen(false);
     };
 
     const handleSubmit = () => {
-        if (isRestoreSeedValid !== true) {
+        if (isRestoreSeedValid !== true || isRestoringRef.current) {
             return;
         }
 
-        deps.restoreMnemonic(restoreResult.value);
-        setRestoreSeed('');
-        closeRestoreModal();
+        isRestoringRef.current = true;
+        setRestoreState('restoring');
+
+        void deps.restoreMnemonic(restoreResult.value).then(
+            () => {
+                isRestoringRef.current = false;
+                setRestoreSeed('');
+                setRestoreState('idle');
+                setIsRestoreModalOpen(false);
+            },
+            () => {
+                isRestoringRef.current = false;
+                setRestoreState('failed');
+            },
+        );
     };
+
+    const handleSeedChange = (seed: string) => {
+        setRestoreSeed(seed);
+        setRestoreState('idle');
+    };
+
+    const isRestoring = restoreState === 'restoring';
 
     return (
         <SettingsRow label="Restore">
-            <Modal
-                open={isRestoreModalOpen}
-                title="Restore Backup"
-                onCancel={closeRestoreModal}
-                onOk={handleSubmit}
-                okText="Restore"
-                cancelText="Cancel"
-                okDisabled={isRestoreSeedValid === false}
-                okButtonTestId="restore-modal-ok"
-            >
-                <Column gap={16}>
-                    <Banner showIcon={true} intent="warning">
-                        Restoring from a backup will overwrite your current data. Make sure you have
-                        a backup of your current mnemonic if you want to keep those data.
-                    </Banner>
+            {isRestoreModalOpen ? (
+                <Modal
+                    open={true}
+                    title="Restore Backup"
+                    onCancel={closeRestoreModal}
+                    onOk={handleSubmit}
+                    okText="Restore"
+                    cancelText="Cancel"
+                    okDisabled={isRestoreSeedValid === false || isRestoring}
+                    okLoading={isRestoring}
+                    closable={!isRestoring}
+                    maskClosable={!isRestoring}
+                    keyboard={!isRestoring}
+                    okButtonTestId={RESTORE_MNEMONIC_MODAL_OK}
+                >
+                    <Column gap={16}>
+                        <Banner showIcon={true} intent="warning">
+                            Restoring from a backup will overwrite your current data. Make sure you
+                            have a backup of your current mnemonic if you want to keep those data.
+                        </Banner>
 
-                    <Textarea
-                        value={restoreSeed}
-                        onChange={setRestoreSeed}
-                        placeholder="Enter your backup phrase here"
-                        rows={6}
-                        testId="restore-seed-input"
-                        {...(restoreSeed !== '' && !isRestoreSeedValid
-                            ? { status: 'error' as const }
-                            : {})}
-                        style={{ width: '100%' }}
-                    />
-                </Column>
-            </Modal>
-            <Button onClick={openRestoreModal} intent="primary" testId="restore-backup-button">
+                        {restoreState === 'failed' ? (
+                            <Banner showIcon={true} intent="danger" testId={RESTORE_MNEMONIC_ERROR}>
+                                The backup could not be restored. Your current backup is still
+                                active.
+                            </Banner>
+                        ) : null}
+
+                        <Textarea
+                            value={restoreSeed}
+                            onChange={handleSeedChange}
+                            placeholder="Enter your backup phrase here"
+                            rows={6}
+                            testId={RESTORE_MNEMONIC_INPUT}
+                            {...(restoreSeed !== '' && !isRestoreSeedValid
+                                ? { status: 'error' as const }
+                                : {})}
+                            style={{ width: '100%' }}
+                        />
+                    </Column>
+                </Modal>
+            ) : null}
+            <Button
+                onClick={openRestoreModal}
+                intent="primary"
+                testId={RESTORE_MNEMONIC_OPEN_BUTTON}
+            >
                 Restore Backup
             </Button>
         </SettingsRow>

--- a/packages/fragment-evolu/src/createRestoreMnemonic.test.ts
+++ b/packages/fragment-evolu/src/createRestoreMnemonic.test.ts
@@ -1,0 +1,29 @@
+import { type EvoluSchema, Mnemonic } from '@evolu/common';
+import { describe, expect, test, vi } from 'vitest';
+import { createRestoreMnemonic } from './createRestoreMnemonic';
+
+const mnemonic = Mnemonic.orThrow(
+    'legal winner thank year wave sausage worth useful legal winner thank yellow',
+);
+
+describe(createRestoreMnemonic.name, () => {
+    test('persists the mnemonic inside the owner restoration transaction', async () => {
+        const setEvoluMnemonic = vi.fn(() => Promise.resolve());
+        const restoreOwner = vi.fn(async params => {
+            expect(setEvoluMnemonic).not.toHaveBeenCalled();
+            await params.persistMnemonic();
+        });
+        const restoreMnemonic = createRestoreMnemonic<EvoluSchema>({
+            setEvoluMnemonic,
+            ensureEvoluStorage: () => Promise.resolve({ restoreOwner } as never),
+        });
+
+        await restoreMnemonic(mnemonic);
+
+        expect(restoreOwner).toHaveBeenCalledWith({
+            mnemonic,
+            persistMnemonic: expect.any(Function),
+        });
+        expect(setEvoluMnemonic).toHaveBeenCalledExactlyOnceWith(mnemonic);
+    });
+});

--- a/packages/fragment-evolu/src/createRestoreMnemonic.ts
+++ b/packages/fragment-evolu/src/createRestoreMnemonic.ts
@@ -14,6 +14,8 @@ export const createRestoreMnemonic =
     <S extends EvoluSchema>(deps: RestoreMnemonicDeps<S>): RestoreMnemonic =>
     async mnemonic => {
         const storage = await deps.ensureEvoluStorage();
-        await deps.setEvoluMnemonic(mnemonic);
-        await storage.restoreOwner(mnemonic);
+        await storage.restoreOwner({
+            mnemonic,
+            persistMnemonic: () => deps.setEvoluMnemonic(mnemonic),
+        });
     };


### PR DESCRIPTION
## Summary

- restore Evolu owners transactionally with rollback when mnemonic persistence fails
- rebind owner-scoped query subscriptions and ignore stale owner updates
- await restore in the UI, prevent duplicate submissions, and report failures
- cover Price Converter restored-owner data and continued updates

## Verification

- pnpm format
- pnpm lint:eslint:fix
- pnpm lint:biome
- pnpm lint:eslint
- pnpm typecheck
- pnpm test
- pnpm knip

Addresses finding 3 in #86.