### PR TITLE
Fix Evolu storage lifecycle races

### DIFF
--- a/apps/price-converter/src/converter/reorderCurrency.test.ts
+++ b/apps/price-converter/src/converter/reorderCurrency.test.ts
@@ -25,6 +25,7 @@ const createTestDeps = (
 });
 
 const mockEvoluStorage = (upsert: EvoluStorage['evolu']['upsert']): EvoluStorage => ({
+    status: 'ready',
     evolu: { upsert } as EvoluStorage['evolu'],
     activeOwner: { id: 'test-owner' } as Owner,
     updateRelayUrls: vi.fn(),

--- a/apps/price-converter/src/state/addCurrency.test.ts
+++ b/apps/price-converter/src/state/addCurrency.test.ts
@@ -8,6 +8,7 @@ import type { EvoluStorage } from './evolu/schema.js';
 const USD = getOrThrow(CurrencyCode.fromUnknown('USD'));
 
 const mockEvoluStorage = (upsert: unknown): EvoluStorage => ({
+    status: 'ready',
     evolu: { upsert: upsert as EvoluStorage['evolu']['upsert'] } as EvoluStorage['evolu'],
     activeOwner: { id: 'test-owner' } as Owner,
     updateRelayUrls: vi.fn(),

--- a/packages/evolu/src/EvoluStorage.ts
+++ b/packages/evolu/src/EvoluStorage.ts
@@ -5,7 +5,10 @@ export type RestoreOwnerParams = {
     readonly persistMnemonic: () => Promise<void>;
 };
 
+export type EvoluStorageStatus = 'ready' | 'restoring' | 'disposing' | 'disposed';
+
 export type EvoluStorage<S extends EvoluSchema> = {
+    readonly status: EvoluStorageStatus;
     readonly evolu: Evolu<S>;
     readonly activeOwner: Owner;
     readonly updateRelayUrls: (urls: ReadonlyArray<string>) => Promise<void>;

--- a/packages/evolu/src/createEnsureEvoluStorage.test.ts
+++ b/packages/evolu/src/createEnsureEvoluStorage.test.ts
@@ -8,6 +8,82 @@ const mnemonic = Mnemonic.orThrow(
 );
 
 describe(createEnsureEvoluStorage.name, () => {
+    test('shares one in-flight creation between concurrent callers', async () => {
+        let resolveOwner: ((value: typeof mnemonic) => void) | undefined;
+        const ownerPromise = new Promise<typeof mnemonic>(resolve => {
+            resolveOwner = resolve;
+        });
+        const storage = mockEvoluStorage([]);
+        const createEvoluStorage = vi.fn(() => Promise.resolve(storage));
+        const ensureEvoluOwner = vi.fn(() => ownerPromise);
+        const ensureEvoluStorage = createEnsureEvoluStorage({
+            deps: {
+                createEvoluStorage,
+                ensureEvoluOwner,
+                getEvoluRelayUrls: () => [],
+                onOwnerUsed: vi.fn(),
+            },
+            schema: TodoTestSchema,
+            appName: 'minimalist-apps-test',
+        });
+
+        const first = ensureEvoluStorage();
+        const second = ensureEvoluStorage();
+
+        expect(first).toBe(second);
+        expect(ensureEvoluOwner).toHaveBeenCalledOnce();
+        resolveOwner?.(mnemonic);
+        await expect(Promise.all([first, second])).resolves.toEqual([storage, storage]);
+        expect(createEvoluStorage).toHaveBeenCalledOnce();
+    });
+
+    test('retries creation after a failed attempt', async () => {
+        const storage = mockEvoluStorage([]);
+        const creationError = new Error('worker creation failed');
+        const createEvoluStorage = vi
+            .fn()
+            .mockRejectedValueOnce(creationError)
+            .mockResolvedValueOnce(storage);
+        const ensureEvoluStorage = createEnsureEvoluStorage({
+            deps: {
+                createEvoluStorage,
+                ensureEvoluOwner: () => Promise.resolve(mnemonic),
+                getEvoluRelayUrls: () => [],
+                onOwnerUsed: vi.fn(),
+            },
+            schema: TodoTestSchema,
+            appName: 'minimalist-apps-test',
+        });
+
+        await expect(ensureEvoluStorage()).rejects.toBe(creationError);
+        await expect(ensureEvoluStorage()).resolves.toBe(storage);
+        expect(createEvoluStorage).toHaveBeenCalledTimes(2);
+    });
+
+    test('creates a fresh instance after the cached storage is disposed', async () => {
+        const firstStorage = mockEvoluStorage([]);
+        const secondStorage = mockEvoluStorage([]);
+        const createEvoluStorage = vi
+            .fn()
+            .mockResolvedValueOnce(firstStorage)
+            .mockResolvedValueOnce(secondStorage);
+        const ensureEvoluStorage = createEnsureEvoluStorage({
+            deps: {
+                createEvoluStorage,
+                ensureEvoluOwner: () => Promise.resolve(mnemonic),
+                getEvoluRelayUrls: () => [],
+                onOwnerUsed: vi.fn(),
+            },
+            schema: TodoTestSchema,
+            appName: 'minimalist-apps-test',
+        });
+
+        await expect(ensureEvoluStorage()).resolves.toBe(firstStorage);
+        await firstStorage.dispose();
+        await expect(ensureEvoluStorage()).resolves.toBe(secondStorage);
+        expect(createEvoluStorage).toHaveBeenCalledTimes(2);
+    });
+
     test('reads the latest configured relays when storage is first created', async () => {
         const storage = mockEvoluStorage([]);
         const createEvoluStorage = vi.fn(() => Promise.resolve(storage));

--- a/packages/evolu/src/createEnsureEvoluStorage.ts
+++ b/packages/evolu/src/createEnsureEvoluStorage.ts
@@ -39,19 +39,74 @@ export const createEnsureEvoluStorage = <S extends EvoluSchema>({
     // shardPath,
 }: CreateEnsureEvoluProps<S>): EnsureEvoluStorage<S> => {
     let storage: EvoluStorage<S> | null = null;
+    let pendingStorage: Promise<EvoluStorage<S>> | null = null;
 
-    return async () => {
-        if (storage === null) {
-            storage = await deps.createEvoluStorage({
+    const createStorage = () => {
+        const creation = (async () =>
+            deps.createEvoluStorage({
                 mnemonic: await deps.ensureEvoluOwner(),
                 schema,
                 appName,
                 onOwnerUsed: deps.onOwnerUsed,
                 urls: deps.getEvoluRelayUrls(),
                 // shardPath,
-            });
+            }))();
+        pendingStorage = creation;
+
+        void creation.then(
+            createdStorage => {
+                storage = createdStorage;
+
+                if (pendingStorage === creation) {
+                    pendingStorage = null;
+                }
+            },
+            () => {
+                if (pendingStorage === creation) {
+                    pendingStorage = null;
+                }
+            },
+        );
+
+        return creation;
+    };
+
+    const ensureEvoluStorage: EnsureEvoluStorage<S> = () => {
+        if (pendingStorage !== null) {
+            return pendingStorage;
         }
 
-        return storage;
+        if (storage?.status === 'disposing') {
+            const disposingStorage = storage;
+            const waitForDisposal = disposingStorage
+                .dispose()
+                .catch(() => undefined)
+                .then(() => {
+                    if (storage === disposingStorage) {
+                        storage = null;
+                    }
+
+                    if (pendingStorage === waitForDisposal) {
+                        pendingStorage = null;
+                    }
+
+                    return ensureEvoluStorage();
+                });
+            pendingStorage = waitForDisposal;
+
+            return waitForDisposal;
+        }
+
+        if (storage?.status === 'disposed') {
+            storage = null;
+        }
+
+        if (storage === null) {
+            return createStorage();
+        }
+
+        return Promise.resolve(storage);
     };
+
+    return ensureEvoluStorage;
 };

--- a/packages/evolu/src/createEvoluStorageFactory.test.ts
+++ b/packages/evolu/src/createEvoluStorageFactory.test.ts
@@ -8,6 +8,22 @@ import { createEvoluStorageFactory } from './createEvoluStorageFactory';
 import { TodoTestSchema } from './mockEvoluStorage';
 import { testCreateRunWithEvoluDeps } from './testCreateRunWithEvoluDeps';
 
+const restoredMnemonic = Mnemonic.orThrow(
+    'legal winner thank year wave sausage worth useful legal winner thank yellow',
+);
+
+const createPendingPromise = <T>() => {
+    let resolve: ((value: T) => void) | undefined;
+    const promise = new Promise<T>(promiseResolve => {
+        resolve = promiseResolve;
+    });
+
+    return {
+        promise,
+        resolve: (value: T) => resolve?.(value),
+    };
+};
+
 describe(createEvoluStorageFactory.name, () => {
     test('restoreOwner recreates evolu instance and updates active owner', async () => {
         await using run = await testCreateRunWithEvoluDeps();
@@ -90,6 +106,7 @@ describe(createEvoluStorageFactory.name, () => {
             }),
         ).rejects.toBe(persistenceError);
 
+        expect(storage.status).toBe('ready');
         expect(storage.evolu).toBe(first.evolu);
         expect(storage.activeOwner).toBe(first.owner);
         expect(first.evolu[Symbol.asyncDispose]).not.toHaveBeenCalled();
@@ -105,5 +122,129 @@ describe(createEvoluStorageFactory.name, () => {
         ]);
 
         await storage.dispose();
+    });
+
+    test('rejects concurrent owner restoration', async () => {
+        const first = {
+            evolu: {
+                [Symbol.asyncDispose]: vi.fn(() => Promise.resolve()),
+            } as unknown as Evolu<TodoTestSchema>,
+            owner: { id: 'first-owner' } as Owner,
+            updateRelayUrls: vi.fn(),
+        };
+        const candidate = {
+            evolu: {
+                [Symbol.asyncDispose]: vi.fn(() => Promise.resolve()),
+            } as unknown as Evolu<TodoTestSchema>,
+            owner: { id: 'candidate-owner' } as Owner,
+            updateRelayUrls: vi.fn(),
+        };
+        const pendingCandidate = createPendingPromise<typeof candidate>();
+        const createEvolu = vi
+            .fn()
+            .mockResolvedValueOnce(first)
+            .mockReturnValueOnce(
+                pendingCandidate.promise,
+            ) as unknown as CreateEvolu<TodoTestSchema>;
+        const storage = await createEvoluStorageFactory<TodoTestSchema>({ createEvolu })({
+            mnemonic: Mnemonic.orThrow(
+                'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+            ),
+            schema: TodoTestSchema,
+            appName: 'minimalist-apps-test',
+            urls: [],
+        });
+
+        const firstRestore = storage.restoreOwner({
+            mnemonic: restoredMnemonic,
+            persistMnemonic: () => Promise.resolve(),
+        });
+
+        expect(storage.status).toBe('restoring');
+        await expect(
+            storage.restoreOwner({
+                mnemonic: restoredMnemonic,
+                persistMnemonic: () => Promise.resolve(),
+            }),
+        ).rejects.toThrow('restoring');
+
+        pendingCandidate.resolve(candidate);
+        await firstRestore;
+        expect(storage.status).toBe('ready');
+
+        await storage.dispose();
+    });
+
+    test('waits for restoration before disposing and rejects use after disposal', async () => {
+        const events: Array<string> = [];
+        const first = {
+            evolu: {
+                [Symbol.asyncDispose]: vi.fn(() => {
+                    events.push('dispose:first');
+
+                    return Promise.resolve();
+                }),
+            } as unknown as Evolu<TodoTestSchema>,
+            owner: { id: 'first-owner' } as Owner,
+            updateRelayUrls: vi.fn(),
+        };
+        const candidate = {
+            evolu: {
+                [Symbol.asyncDispose]: vi.fn(() => {
+                    events.push('dispose:candidate');
+
+                    return Promise.resolve();
+                }),
+            } as unknown as Evolu<TodoTestSchema>,
+            owner: { id: 'candidate-owner' } as Owner,
+            updateRelayUrls: vi.fn(),
+        };
+        const pendingCandidate = createPendingPromise<typeof candidate>();
+        const createEvolu = vi
+            .fn()
+            .mockResolvedValueOnce(first)
+            .mockReturnValueOnce(
+                pendingCandidate.promise,
+            ) as unknown as CreateEvolu<TodoTestSchema>;
+        const storage = await createEvoluStorageFactory<TodoTestSchema>({ createEvolu })({
+            mnemonic: Mnemonic.orThrow(
+                'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+            ),
+            schema: TodoTestSchema,
+            appName: 'minimalist-apps-test',
+            urls: [],
+        });
+        const restore = storage.restoreOwner({
+            mnemonic: restoredMnemonic,
+            persistMnemonic: () => {
+                events.push('persist:candidate');
+
+                return Promise.resolve();
+            },
+        });
+        const firstDispose = storage.dispose();
+        const secondDispose = storage.dispose();
+
+        expect(firstDispose).toBe(secondDispose);
+        expect(storage.status).toBe('disposing');
+        expect(events).toEqual([]);
+
+        pendingCandidate.resolve(candidate);
+        await restore;
+        await firstDispose;
+
+        expect(events).toEqual(['persist:candidate', 'dispose:first', 'dispose:candidate']);
+        expect(storage.status).toBe('disposed');
+        expect(() => storage.evolu).toThrow('disposed');
+        expect(() => storage.activeOwner).toThrow('disposed');
+        await expect(storage.updateRelayUrls([])).rejects.toThrow('disposed');
+        await expect(
+            storage.restoreOwner({
+                mnemonic: restoredMnemonic,
+                persistMnemonic: () => Promise.resolve(),
+            }),
+        ).rejects.toThrow('disposed');
+        expect(() => storage.subscribeOwnerChange(vi.fn())).toThrow('disposed');
+        await expect(storage.dispose()).resolves.toBeUndefined();
     });
 });

--- a/packages/evolu/src/createEvoluStorageFactory.ts
+++ b/packages/evolu/src/createEvoluStorageFactory.ts
@@ -1,7 +1,7 @@
 import type { Mnemonic } from '@evolu/common';
 import type { Evolu, EvoluSchema, Owner, ValidateSchema } from '@evolu/common/local-first';
 import type { CreateEvolu } from './createEvoluFactory';
-import type { EvoluStorage, RestoreOwnerParams } from './EvoluStorage';
+import type { EvoluStorage, EvoluStorageStatus, RestoreOwnerParams } from './EvoluStorage';
 
 type CreateEvoluStorageFactoryDeps<S extends EvoluSchema> = {
     readonly createEvolu: CreateEvolu<S>;
@@ -49,10 +49,28 @@ export const createEvoluStorageFactory =
 
         props.onOwnerUsed?.(activeOwner);
 
-        let isDisposed = false;
+        let status: EvoluStorageStatus = 'ready';
+        let restorePromise: Promise<void> | null = null;
+        let disposePromise: Promise<void> | null = null;
+
+        const lifecycleError = (operation: string) =>
+            new Error(`Cannot ${operation} while Evolu storage is ${status}.`);
+
+        const assertReady = (operation: string) => {
+            if (status !== 'ready') {
+                throw lifecycleError(operation);
+            }
+        };
+
+        const assertNotDisposed = (operation: string) => {
+            if (status === 'disposed') {
+                throw lifecycleError(operation);
+            }
+        };
 
         const updateRelayUrls = (urls: ReadonlyArray<string>): Promise<void> =>
             Promise.resolve().then(() => {
+                assertReady('update relay URLs');
                 updateActiveRelayUrls(urls);
                 relayUrls = urls;
             });
@@ -71,7 +89,7 @@ export const createEvoluStorageFactory =
             notifyOwnerChange();
         };
 
-        const restoreOwner = async (params: RestoreOwnerParams): Promise<void> => {
+        const restoreOwnerTransaction = async (params: RestoreOwnerParams): Promise<void> => {
             const previous = {
                 evolu,
                 owner: activeOwner,
@@ -99,29 +117,80 @@ export const createEvoluStorageFactory =
             await disposeEvolu(previous.evolu);
         };
 
+        const restoreOwner = (params: RestoreOwnerParams): Promise<void> => {
+            try {
+                assertReady('restore owner');
+            } catch (error) {
+                return Promise.reject(error);
+            }
+
+            status = 'restoring';
+            const operation = restoreOwnerTransaction(params);
+            const trackedOperation = operation.finally(() => {
+                restorePromise = null;
+
+                if (status === 'restoring') {
+                    status = 'ready';
+                }
+            });
+            restorePromise = trackedOperation;
+
+            return trackedOperation;
+        };
+
+        const dispose = (): Promise<void> => {
+            if (status === 'disposed') {
+                return Promise.resolve();
+            }
+
+            if (disposePromise !== null) {
+                return disposePromise;
+            }
+
+            const activeRestore = restorePromise;
+            status = 'disposing';
+            const operation = Promise.resolve()
+                .then(async () => {
+                    try {
+                        await activeRestore;
+                    } catch {
+                        // The restore transaction already rolled back its candidate owner.
+                    }
+                    await disposeEvolu(evolu);
+                })
+                .finally(() => {
+                    status = 'disposed';
+                    ownerChangeListeners.clear();
+                });
+            disposePromise = operation;
+
+            return operation;
+        };
+
         return {
+            get status() {
+                return status;
+            },
             get evolu() {
+                assertNotDisposed('access Evolu');
+
                 return evolu;
             },
             get activeOwner() {
+                assertNotDisposed('access active owner');
+
                 return activeOwner;
             },
             updateRelayUrls,
             restoreOwner,
             subscribeOwnerChange: listener => {
+                assertNotDisposed('subscribe to owner changes');
                 ownerChangeListeners.add(listener);
 
                 return () => {
                     ownerChangeListeners.delete(listener);
                 };
             },
-            dispose: async () => {
-                if (isDisposed) {
-                    return;
-                }
-
-                isDisposed = true;
-                await disposeEvolu(evolu);
-            },
+            dispose,
         };
     };

--- a/packages/evolu/src/createSubscribableQuery.test.ts
+++ b/packages/evolu/src/createSubscribableQuery.test.ts
@@ -55,6 +55,7 @@ describe(createSubscribableQuery.name, () => {
         const ownerChangeListeners = new Set<() => void>();
         let activeStorage = firstStorage;
         const storage: EvoluStorage<TodoTestSchema> = {
+            status: 'ready',
             get evolu() {
                 return activeStorage.evolu;
             },

--- a/packages/evolu/src/index.ts
+++ b/packages/evolu/src/index.ts
@@ -11,7 +11,7 @@ export {
 } from './createEnsureEvoluStorage';
 export { createEvoluCompositionRoot } from './createEvoluCompositionRoot';
 export { createSubscribableQuery } from './createSubscribableQuery';
-export type { EvoluStorage, RestoreOwnerParams } from './EvoluStorage';
+export type { EvoluStorage, EvoluStorageStatus, RestoreOwnerParams } from './EvoluStorage';
 export { installPolyfills } from './installPolyfills';
 export {
     DEFAULT_EVOLU_RELAY_URLS,

--- a/packages/evolu/src/mockEvoluStorage.ts
+++ b/packages/evolu/src/mockEvoluStorage.ts
@@ -24,8 +24,12 @@ type MockEvoluStorage = EvoluStorage<TodoTestSchema> & {
 export const mockEvoluStorage = (initialRows: ReadonlyArray<TodoRow>): MockEvoluStorage => {
     let rows = initialRows;
     let onQueryChanged: (() => void) | undefined;
+    let status: EvoluStorage<TodoTestSchema>['status'] = 'ready';
 
     return {
+        get status() {
+            return status;
+        },
         evolu: {
             subscribeQuery: () => (listener: Listener) => {
                 onQueryChanged = listener;
@@ -44,7 +48,11 @@ export const mockEvoluStorage = (initialRows: ReadonlyArray<TodoRow>): MockEvolu
         updateRelayUrls: async () => {},
         restoreOwner: async () => {},
         subscribeOwnerChange: () => () => {},
-        dispose: async () => {},
+        dispose: () => {
+            status = 'disposed';
+
+            return Promise.resolve();
+        },
 
         emitUpdate: nextRows => {
             rows = nextRows;


### PR DESCRIPTION
## Summary

- share one in-flight Evolu storage creation across concurrent callers
- reset failed creation attempts and recreate disposed cached storage
- model ready, restoring, disposing, and disposed storage states
- reject conflicting restores and use after disposal
- make concurrent disposal idempotent and wait for active restoration

## Verification

- pnpm format
- pnpm lint:eslint:fix
- pnpm lint:biome
- pnpm lint:eslint
- pnpm typecheck
- pnpm test
- pnpm knip

Addresses finding 4 in #86.